### PR TITLE
Asynchronous sound play to avoid repetitions and improve UI response

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@
 
 DEBUGGING:=
 
-LIBS:=-lXft -lImlib2 -lstdc++ `pkg-config --libs libstartup-notification-1.0` -lmpg123 -lao
+LIBS:=-lXft -lImlib2 -lstdc++ `pkg-config --libs libstartup-notification-1.0` -lmpg123 -lao -lpthread
 XFTINC:=-I/usr/include/freetype2
 SNINC=-I/usr/include/startup-notification-1.0
 

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -15,7 +15,6 @@
 #include "configuration.h"
 #include "background.h"
 #include "logging.h"
-#include "sound.h"
 
 Background::Background (Configuration *loaded_conf)
 {
@@ -63,9 +62,6 @@ bool Background::load (Display *display)
   string background_file;
   Imlib_Image tmpimg, buffer;
   bool bsuccess=false;
-
-  Sound ksound = Sound(pconf);
-  ksound.play_sound("welcomesound");
 
   buffer = imlib_create_image (deskw, deskh);
   if (!buffer)

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -102,14 +102,19 @@ bool Configuration::load_conf(const char *filename)
 	configuration["enablesound"] = value;
       }
 
-      if (token == "WelcomeSound:") {
+      if (token == "SoundWelcome:") {
 	ifile >> value;
-	configuration["welcomesound"] = value;
+	configuration["soundwelcome"] = value;
       }
 
-      if (token == "DisabledIconSound:") {
+      if (token == "SoundLaunchApp:") {
 	ifile >> value;
-	configuration["disablediconsound"] = value;
+	configuration["soundlaunchapp"] = value;
+      }
+
+      if (token == "SoundDisabledIcon:") {
+	ifile >> value;
+	configuration["sounddisabledicon"] = value;
       }
 
     }

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -33,6 +33,7 @@ Desktop::Desktop(Configuration *loaded_conf)
 {
   pconf = loaded_conf;
   finish = false;
+  ksound = new Sound(pconf);
 }
 
 Desktop::~Desktop(void)
@@ -156,8 +157,7 @@ bool Desktop::process_and_dispatch(Display *display)
 	      // Protect the UI experience by disallowing a new app startup if one is in progress
 	      if (bstarted == true && (ev.xbutton.time - last_dblclick < pconf->get_config_int("iconstartdelay"))) {
 		log1 ("icon start request too fast (iconstartdelay)", pconf->get_config_int("iconstartdelay"));
-		Sound ksound = Sound(pconf);
-		ksound.play_sound("disablediconsound");
+		ksound->play_sound("sounddisabledicon");
 	      }
 	      else {
 		log ("DOUBLE CLICK!");
@@ -167,13 +167,13 @@ bool Desktop::process_and_dispatch(Display *display)
 		// Save to request an app startup: tell the icon a mouse double click needs processing
 		if (iconHandlers[wtarget]->is_singleton_running () == false) {
 		  // Notify system we are about to load a new app (hourglass)
+		  ksound->play_sound("soundlaunchapp");
 		  notify_startup_load (display, iconHandlers[wtarget]->iconid, ev.xbutton.time);
 		  bstarted = iconHandlers[wtarget]->double_click (display, ev);
 		}
 		else {
 		  // The app is already running, icon is disabled
-		  Sound ksound = Sound(pconf);
-		  ksound.play_sound("disablediconsound");
+		  ksound->play_sound("sounddisabledicon");
 		}
 	      }
 	    }

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -24,6 +24,7 @@ class Desktop
   Configuration *pconf;
   bool finish;
   static int error_trap_depth;
+  Sound *ksound;
 
  public:
   Desktop(Configuration *loaded_conf);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 #include "main.h"
 #include "icon.h"
 #include "background.h"
+#include "sound.h"
 #include "desktop.h"
 #include "logging.h"
 
@@ -101,6 +102,10 @@ int main(int argc, char *argv[])
   bg.setup(display);
   bg.load(display);
   bg.draw(display);
+
+  // Play sound once the background is displayed
+  Sound ksound = Sound(&conf);
+  ksound.play_sound("soundwelcome");
 
   // startup delay
   //unsigned long ms=1000*2000;

--- a/src/sound.h
+++ b/src/sound.h
@@ -24,6 +24,9 @@ class Sound
   mpg123_handle *mh;
   size_t buffer_size;
   unsigned char *mpg123_outblock_buffer;
+  std::string *tune;
+  pthread_t t;
+  bool playing;
 
  public:
   int enabled;
@@ -33,8 +36,14 @@ class Sound
 
   bool load_chimes(void);
   bool init(void);
-  bool play(std::string filename);
-  void play_sound(string sound_name);
+
+  static void * InternalThreadEntryFunc(void * This)
+  {
+    ((Sound *)This)->play(); return NULL;
+  }
+
+  bool play(void);
+  void play_sound(std::string sound_name);
   bool terminate(void);
   bool set_enabled (bool benabled);
   bool get_enabled (void);


### PR DESCRIPTION
- implemented async method using pthreads
- removed cumulative sound plays, if sound is busy it will return asap
- renamed sound names to "sound.xxx" in the config file.
- welcome sound is played in the background while desktop is loading
- added an event to play a sound when an app is loading
