### PR TITLE
Fixed async sound issue, moving from idesk to kdesk configuration files

### DIFF
--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -29,11 +29,11 @@
 #include "desktop.h"
 #include "logging.h"
 
-Desktop::Desktop(Configuration *loaded_conf)
+Desktop::Desktop(Configuration *loaded_conf, Sound *ksound)
 {
   pconf = loaded_conf;
+  psound = ksound;
   finish = false;
-  ksound = new Sound(pconf);
 }
 
 Desktop::~Desktop(void)
@@ -157,7 +157,7 @@ bool Desktop::process_and_dispatch(Display *display)
 	      // Protect the UI experience by disallowing a new app startup if one is in progress
 	      if (bstarted == true && (ev.xbutton.time - last_dblclick < pconf->get_config_int("iconstartdelay"))) {
 		log1 ("icon start request too fast (iconstartdelay)", pconf->get_config_int("iconstartdelay"));
-		ksound->play_sound("sounddisabledicon");
+		psound->play_sound("sounddisabledicon");
 	      }
 	      else {
 		log ("DOUBLE CLICK!");
@@ -167,13 +167,13 @@ bool Desktop::process_and_dispatch(Display *display)
 		// Save to request an app startup: tell the icon a mouse double click needs processing
 		if (iconHandlers[wtarget]->is_singleton_running () == false) {
 		  // Notify system we are about to load a new app (hourglass)
-		  ksound->play_sound("soundlaunchapp");
+		  psound->play_sound("soundlaunchapp");
 		  notify_startup_load (display, iconHandlers[wtarget]->iconid, ev.xbutton.time);
 		  bstarted = iconHandlers[wtarget]->double_click (display, ev);
 		}
 		else {
 		  // The app is already running, icon is disabled
-		  ksound->play_sound("sounddisabledicon");
+		  psound->play_sound("sounddisabledicon");
 		}
 	      }
 	    }

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -22,12 +22,12 @@ class Desktop
   SnDisplay *sn_display;
   SnLauncherContext *sn_context;
   Configuration *pconf;
+  Sound *psound;
   bool finish;
   static int error_trap_depth;
-  Sound *ksound;
 
  public:
-  Desktop(Configuration *loaded_conf);
+  Desktop(Configuration *loaded_conf, Sound *psound);
   virtual ~Desktop(void);
 
   bool create_icons (Display *display);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
   }
 	  
   // Create and draw desktop icons, then attend user interaction
-  Desktop dsk(&conf);
+  Desktop dsk(&conf, &ksound);
   bool bicons = dsk.create_icons(display);
   log1 ("desktop icons created", (bicons == true ? "successfully" : "errors found"));
 

--- a/src/main.h
+++ b/src/main.h
@@ -2,6 +2,6 @@
 // main.h
 //
 
-#define FILE_KDESKRC       "/usr/share/kano-desktop/idesk/ideskrc"
-#define DIR_KDESKTOP       "/usr/share/kano-desktop/idesk/idesktop"
+#define FILE_KDESKRC       "/usr/share/kano-desktop/kdesk/kdeskrc"
+#define DIR_KDESKTOP       "/usr/share/kano-desktop/kdesk/kdesktop"
 #define DIR_KDESKTOP_USER  ".kdesktop"

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -81,10 +81,6 @@ bool Sound::init(void)
 
 bool Sound::terminate(void)
 {
-  if (playing == true) {
-    pthread_join(t, NULL);
-  }
-
   free (mpg123_outblock_buffer);
   ao_close (dev);
   mpg123_close (mh);


### PR DESCRIPTION
- Two instances of the Sound class would clash when run in parallel
  Using one single instance shared between the startup and the icon event classes
- Renamed idesk configuration files to kdesk namespaces
