### PR TITLE
Support for screen saver in Kdesk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Maintainer: Team Kano <dev@kano.me>
 Section: x11
 Priority: optional
 Standards-Version: 1.1.0
-Build-Depends: libx11-dev, libxft-dev, libimlib2-dev, libstartup-notification0-dev, libao-dev, libmpg123-dev, debhelper (>=9.0.0)
+Build-Depends: libx11-dev, libxft-dev, libimlib2-dev, libstartup-notification0-dev, libao-dev, libmpg123-dev, libxss-dev, debhelper (>=9.0.0)
 
 Package: kdesk
 Architecture: armhf
-Depends: ${misc:Depends}, ${shlibs:Depends}, libao4, libmpg123-0
+Depends: ${misc:Depends}, ${shlibs:Depends}, libao4, libmpg123-0, libxss1
 Provides: idesk
 Conflicts: idesk
 Replaces: idesk

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@
 
 DEBUGGING:=
 
-LIBS:=-lXft -lImlib2 -lstdc++ `pkg-config --libs libstartup-notification-1.0` -lmpg123 -lao -lpthread
+LIBS:=-lXft -lImlib2 -lstdc++ `pkg-config --libs libstartup-notification-1.0` -lmpg123 -lao -lpthread -lXss
 XFTINC:=-I/usr/include/freetype2
 SNINC=-I/usr/include/startup-notification-1.0
 
@@ -22,13 +22,15 @@ all: $(TARGET)
 debug:
 	make all DEBUGGING="-ggdb -O3 -DDEBUG"
 
-$(TARGET): main.o icon.o background.o configuration.o desktop.o sound.o
+# the linkage
+$(TARGET): main.o icon.o background.o configuration.o desktop.o sound.o ssaver.o
 	g++ $(LIBS) $^ -o $(TARGET)
 
+# the compilation
 icon.o: icon.cpp icon.h logging.h configuration.h
 	g++ -c $(DEBUGGING) $(XFTINC) icon.cpp
 
-main.o: main.cpp main.h configuration.h logging.h version.h
+main.o: main.cpp main.h configuration.h logging.h version.h ssaver.h
 	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) main.cpp
 
 background.o: background.cpp logging.h sound.h
@@ -42,3 +44,6 @@ desktop.o: desktop.cpp desktop.h logging.h configuration.h sn_callbacks.cpp soun
 
 sound.o: sound.cpp sound.h
 	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) sound.cpp
+
+ssaver.o: ssaver.cpp ssaver.h
+	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) ssaver.cpp

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -122,6 +122,17 @@ bool Configuration::load_conf(const char *filename)
 	ifile >> value;
 	configuration["background.delay"] = value;
       }
+
+      if (token == "ScreenSaverTimeout:") {
+	ifile >> value;
+	configuration["screensavertimeout"] = value;
+      }
+
+      if (token == "ScreenSaverProgram:") {
+	ifile >> value;
+	configuration["screensaverprogram"] = value;
+      }
+
     }
  
   ifile.close();

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -23,9 +23,12 @@ Sound::Sound (Configuration *loaded_conf)
   driver = 0;
   dev = NULL;
   mh = NULL;
+  set_enabled(false);
   mpg123_outblock_buffer = (unsigned char *) NULL;
-  load_chimes();
-  init();
+
+  if (load_chimes() == true) {
+    init();
+  }
 }
 
 Sound::~Sound (void)
@@ -33,8 +36,10 @@ Sound::~Sound (void)
   if (playing) {
     pthread_join(t, NULL);
   }
-
-  terminate();
+  
+  if (get_enabled() == true) {
+    terminate();
+  }
 }
 
 bool Sound::set_enabled (bool benabled)
@@ -53,6 +58,7 @@ bool Sound::load_chimes(void)
 
   if (configuration->get_config_string ("enablesound") == "true") {
     // TODO: Preload chimes in memory for faster response times
+    set_enabled(true);
     bsuccess = true;
   }
 
@@ -144,7 +150,7 @@ bool Sound::play(void)
 void Sound::play_sound(string sound_name)
 {
   // sound name is the key name specified in the configuration file
-  if (playing == false) {
+  if (playing == false && get_enabled() == true) {
     tune = new std::string (configuration->get_config_string (sound_name));
     pthread_create(&t, NULL, InternalThreadEntryFunc, this);
   }

--- a/src/ssaver.cpp
+++ b/src/ssaver.cpp
@@ -1,0 +1,68 @@
+//
+// ssaver.cpp  -  Class to detect user idle time and fire a screen saver.
+//
+// Copyright (C) 2013-2014 Kano Computing Ltd.
+// License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+//
+// An app to show and bring life to Kano-Make Desktop Icons.
+//
+
+#include "X11/extensions/scrnsaver.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "logging.h"
+#include "ssaver.h"
+
+bool setup_ssaver (KSAVER_DATA *kdata)
+{
+  pthread_t *tssaver = new pthread_t();
+  pthread_create (tssaver, NULL, &idle_time, (void *) kdata);
+  log1 ("SSaver thread started tid", tssaver);
+  return true;
+}
+
+void *idle_time (void *p)
+{
+  bool running=true;
+  Status rc=0;
+  unsigned long ms=1000 * POLL_INTERVAL;
+  unsigned long ultimeout=0L;
+  PKSAVER_DATA pdata=(PKSAVER_DATA) p;
+  XScreenSaverInfo *info = XScreenSaverAllocInfo();
+
+  Display *display = XOpenDisplay(pdata->display_name);
+  if (!display) {
+    log ("Ssaver cannot connect to X Display! No screen saver available");
+    return NULL;
+  }
+  else {
+    log2 ("Setting screen saver - T/O (secs) and program", pdata->idle_timeout, pdata->saver_program);
+  }
+
+  while (running)
+    {
+      log1 ("asking for system idle time on display", display);
+      rc = XScreenSaverQueryInfo(display, DefaultRootWindow(display), info);
+      if (rc)
+	{
+	  if (info->idle > (pdata->idle_timeout * 1000)) {
+	    log2 ("Screen Saver needs be started now (idle, timeout)", info->idle, pdata->idle_timeout * 1000);
+	    rc = system (pdata->saver_program);
+	    log2 ("Screen saver finished: rc, cmdline", rc, pdata->saver_program);
+	  }
+	  else {
+	    log2 ("XScreenSaverQueryInfo rc - idle ms, not screen saver yet...", rc, info->idle);
+	  }
+	}
+      else {
+	log1 ("XScreenSaverQueryInfo failed with rc", rc);
+      }
+      
+      usleep(ms);
+    }
+
+  XFree(info);
+  return NULL;
+}

--- a/src/ssaver.h
+++ b/src/ssaver.h
@@ -1,0 +1,23 @@
+//
+// ssaver.h -  Class to detect user idle time and fire a screen saver.
+//
+// Copyright (C) 2013-2014 Kano Computing Ltd.
+// License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+//
+// An app to show and bring life to Kano-Make Desktop Icons.
+//
+
+#define POLL_INTERVAL 1000            // milliseconds between each system idle query
+
+typedef struct _ksaver_data {
+
+  const char *display_name;                 // Usually this can be set to NULL to attach to first available display
+  unsigned long idle_timeout;         // seconds to idle before starting the screen saver
+  const char *saver_program;                // path to binary program that paints the screen saver
+
+} KSAVER_DATA;
+
+typedef KSAVER_DATA* PKSAVER_DATA;
+
+bool setup_ssaver (KSAVER_DATA *kdata);
+void *idle_time (void *p);


### PR DESCRIPTION
 o 2 new keys in ideskrc: ScreenSaverTimeout (secs) and ScreenSaverProgram, the actual rendering program
 o Uses a new independent thread to wait for user Idle time then fires screen saver
 o Also fixed a minor bug where the EnableSound was always interpreted as a True.
 o At this point working on the actual screen saver: simple program to display on screen until user input
 o Xorg blanking/DPMS timeouts need to be taken care of (default set to 10 minutes as reported by xset -q)
