### PR TITLE
Automatic disable of screen saver and sound

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -5,3 +5,6 @@
 #define FILE_KDESKRC       "/usr/share/kano-desktop/kdesk/kdeskrc"
 #define DIR_KDESKTOP       "/usr/share/kano-desktop/kdesk/kdesktop"
 #define DIR_KDESKTOP_USER  ".kdesktop"
+
+// Primary physical display, used to discern when to play sounds
+#define DEFAULT_DISPLAY    ":0.0"

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -25,10 +25,7 @@ Sound::Sound (Configuration *loaded_conf)
   mh = NULL;
   set_enabled(false);
   mpg123_outblock_buffer = (unsigned char *) NULL;
-
-  if (load_chimes() == true) {
-    init();
-  }
+  load_chimes();
 }
 
 Sound::~Sound (void)


### PR DESCRIPTION
- If the allocated display is not the primary, disable sound
  (for exmaple for VNC sessions)
- If X server does not provide screen saver extensions, don't use it
  (same example for VNC sessions)
