### PR TITLE
Provide new setting to change a double click for a single click

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following keywords allow for extra functionalities in kDesk itself.
  * SoundWelcome - Path to an mp3 sound file to be played on kdesk startup
  * SoundLLaunchApp - Path to an mp3 sound file to be played when the user double clicks on a disabled icon
  * SoundDisabledIcon - Path to an mp3 sound file to be played when the user double clicks and starts an app
+ * OneClick - If this flag is set to true, one single mouse click will start the icon apps. Default is false.
 
 #### Icons Configuration file parameters
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -133,6 +133,11 @@ bool Configuration::load_conf(const char *filename)
 	configuration["screensaverprogram"] = value;
       }
 
+      if (token == "OneClick:") {
+	ifile >> value;
+	configuration["oneclick"] = value;
+      }
+
     }
  
   ifile.close();

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -152,7 +152,7 @@ bool Desktop::process_and_dispatch(Display *display)
 	  // And a grace time period to protect nested double clicks: "clickgrace"
 	  // Note we are listening for both left and right mouse click events.
 	  log3 ("ButtonPress event: window, time, last click", wtarget, ev.xbutton.time, last_click);
-	  if (ev.xbutton.time - last_click < pconf->get_config_int("clickdelay")) 
+	  if (ev.xbutton.time - last_click < pconf->get_config_int("clickdelay") || pconf->get_config_string("oneclick") == "true")
 	    {
 	      // Protect the UI experience by disallowing a new app startup if one is in progress
 	      if (bstarted == true && (ev.xbutton.time - last_dblclick < pconf->get_config_int("iconstartdelay"))) {
@@ -160,7 +160,7 @@ bool Desktop::process_and_dispatch(Display *display)
 		psound->play_sound("sounddisabledicon");
 	      }
 	      else {
-		log ("DOUBLE CLICK!");
+		log ("Processing mouse click startup event");
 		last_dblclick = ev.xbutton.time;
 		bstarted = false;
 


### PR DESCRIPTION
 o If "OneClick" flag is set to true, one single click will
   act as double click events to start the apps.
