### PR TITLE
Display different mouse pointer when hovering icons #696

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The following keywords allow for extra functionalities in kDesk itself.
  * ScreenMedResWidth - Minimal screen width of the screen in pixels to be considered as high resolution wallpaper mode.
                        If the screen resolution falls below this width, the wallpaper "Background.File-medium" will be displayed.
 		       instead of the high resolution ones (background.file-4-3, background.file-16-9). The default is none, which means high resolution.
+ * MouseHoverIcon - ID of a mouse pointer to display when mouse moves over each icon. The default is XC_hand1 (#58), a waiting hand icon
+                    as defined by the official font icon cursor table, which can be replaced by themes: http://tronche.com/gui/x/xlib/appendix/b/
+		    Please provide the constants in numerical form.
 
 #### Icons Configuration file parameters
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -148,6 +148,10 @@ bool Configuration::load_conf(const char *filename)
 	configuration["background.file-medium"] = value;
       }
 
+      if (token == "MouseHoverIcon:") {
+	ifile >> value;
+	configuration["mousehovericon"] = value;
+      }
     }
  
   ifile.close();

--- a/src/icon.h
+++ b/src/icon.h
@@ -10,16 +10,24 @@
 #include <X11/Xlib.h>
 #include <X11/Xft/Xft.h>
 #include <Imlib2.h>
+#include <X11/cursorfont.h>
 #include "configuration.h"
+
+// Default icon cursor when mouse moves over the icon
+// 
+#define DEFAULT_ICON_CURSOR XC_hand1
 
 class Icon
 {
  private:
   Configuration *configuration;
+  Display *icon_display;
   Window win;
   int iconx, icony, iconw, iconh;
   int shadowx, shadowy;
   int icontitlegap;
+  Cursor cursor;
+  int cursor_id;
   Imlib_Updates updates;
   Imlib_Image image;
   Imlib_Image backsafe;
@@ -41,6 +49,7 @@ class Icon
   bool is_singleton_running (void);
   Window create(Display *display);
   void initialize(Display *display);
+  void destroy(void);
 
   void draw(Display *display, XEvent ev);
   bool blink_icon(Display *display, XEvent ev);


### PR DESCRIPTION
- A new key "MouseHoverIcon" allows for displaying custom mouse pointer
- Added a destroy method for general cleanup of cursor and other X11 resources.
