### PR TITLE
Changing strategy to fix seldom blank screen

### DIFF
--- a/src/ssaver.cpp
+++ b/src/ssaver.cpp
@@ -52,6 +52,9 @@ void *idle_time (void *p)
   unsigned long ultimeout=0L;
   PKSAVER_DATA pdata=(PKSAVER_DATA) p;
 
+  // Initial X11 connection delay
+  usleep(ms);
+
   Display *display = XOpenDisplay(pdata->display_name);
   if (!display) {
     log ("Ssaver cannot connect to X Display! No screen saver available");
@@ -61,17 +64,11 @@ void *idle_time (void *p)
     log2 ("Setting screen saver - T/O (secs) and program", pdata->idle_timeout, pdata->saver_program);
   }
 
-  XLockDisplay(display);
   XScreenSaverInfo *info = XScreenSaverAllocInfo();
-  XUnlockDisplay(display);
-
   while (running)
     {
       log1 ("asking for system idle time on display", display);
-      XLockDisplay(display);
       rc = XScreenSaverQueryInfo(display, DefaultRootWindow(display), info);
-      XUnlockDisplay(display);
-
       if (rc)
 	{
 	  // If idle timeout expires, and focus is on the GUI tty device, then launch the screen saver
@@ -91,7 +88,7 @@ void *idle_time (void *p)
       else {
 	log1 ("XScreenSaverQueryInfo failed with rc", rc);
       }
-      
+
       usleep(ms);
     }
 

--- a/src/ssaver.h
+++ b/src/ssaver.h
@@ -7,7 +7,7 @@
 // An app to show and bring life to Kano-Make Desktop Icons.
 //
 
-#define POLL_INTERVAL    60000           // milliseconds between each system idle query
+#define POLL_INTERVAL    15000           // milliseconds between each system idle query
 #define XREFRESH         "xrefresh"      // called after the screen saver to redraw the desktop
 #define TTY_QUERY        "/dev/tty1"     // name of the tty device to use as a trampoline to know who has the focus
 #define GUI_TTY_DEVICE   7               // tty device number where the GUI XServer is running, normally tty7


### PR DESCRIPTION
- Previous fix has proved to be wrong: 0da4d73169b86dfa91e725bbb38ed58811499c7d
  changing the inter-thread synchronization by delaying the screen
  saver thread xlib job so that kdesk has time to create desktop
  icons and dispatch creation events.
