### PR TITLE
Refresh feature

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -146,9 +146,6 @@ bool Background::load (Display *display)
 	  imlib_free_image_and_decache();
 	  XFreePixmap(display, pmap);
 
-	  // Ask all top level windows to repaint
-	  refresh_background(display);
-
 	  bsuccess = true;
 	  log1 ("desktop background created successfully", image);
 	}
@@ -169,6 +166,14 @@ int Background::refresh_background(Display *display)
     {
       for (int i=0; i < nchildren_return; i++)
 	{
+	  // 
+	  XEvent xev;
+	  memset (&xev, 0x00, sizeof (xev));
+	  xev.type = Expose;
+	  xev.xexpose.window = children_return[i];
+	  XSendEvent (display, children_return[i], 0, ExposureMask, &xev);
+	  XFlush (display);
+
 	  // clear the window area
 	  XClearWindow (display, children_return[i]);
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -23,7 +23,6 @@ Configuration::Configuration()
 
 Configuration::~Configuration()
 {
-  ifile.close();
 }
 
 bool Configuration::load_conf(const char *filename)
@@ -200,7 +199,7 @@ bool Configuration::parse_icon (const char *directory, string fname, int iconid)
 	// Collect the key name aka "token"
 	iss >> token;
 	
-	// Then collec the token's value, up to EOL
+	// Then collect the token's value, up to EOL
 	while (!iss.eof()) {
 	  iss >> temp;
 	  value += temp;
@@ -356,6 +355,23 @@ void Configuration::dump()
       {
 	log2 ("icon key", it->first, it->second);
       }
-
   }
+}
+
+void Configuration::reset(void)
+{
+  std::map<string,string>::iterator it;
+  for (it=configuration.begin(); it != configuration.end(); ++it)
+    {
+      configuration.erase(it);
+    }
+
+  for (int c=0; c < numicons; c++) {
+    for (it=icons[c].begin(); it != icons[c].end(); ++it)
+      {
+	icons[c].erase (it);
+      }
+  }
+
+  numicons = 0;
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -30,6 +30,7 @@ class Configuration
   bool load_icons (const char *directory);
   bool parse_icon (const char *directory, std::string fname, int iconid);
   void dump (void);
+  void reset(void);
 
   std::string get_config_string(std::string item);
   unsigned int get_config_int(std::string item);

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -15,9 +15,14 @@
 #define SN_API_NOT_YET_FROZEN
 #include <libsn/sn.h>
 
+#define KDESK_CONTROL_WINDOW_NAME "KdeskControlWindow"
+#define KDESK_SIGNAL_FINISH       "KSIG_FINISH"
+#define KDESK_SIGNAL_RELOAD       "KSIG_RELOAD"
+
 class Desktop
 {
  private:
+  Window wcontrol;
   std::map <Window, Icon *> iconHandlers;
   SnDisplay *sn_display;
   SnLauncherContext *sn_context;
@@ -25,18 +30,22 @@ class Desktop
   Sound *psound;
   bool finish;
   static int error_trap_depth;
+  int numicons;
+  Atom atom_finish, atom_reload;
 
  public:
-  Desktop(Configuration *loaded_conf, Sound *psound);
+  Desktop(void);
   virtual ~Desktop(void);
 
   bool create_icons (Display *display);
+  bool destroy_icons (Display *display);
 
   bool notify_startup_load (Display *display, int iconid, Time time);
   bool notify_startup_ready (Display *display);
   void notify_startup_event (Display *display, XEvent *pev);
 
+  bool initialize(Display *display, Configuration *loaded_conf, Sound *psound);
   bool process_and_dispatch(Display *display);
+  bool send_signal (Display *display, const char *signalName);
   bool finalize(void);
-
 };

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -27,6 +27,7 @@ Icon::Icon (Configuration *loaded_conf, int iconidx)
   iconx=icony=iconw=iconh=0;
   shadowx=shadowy=0;
   iconMapNone = iconMapGlow = (unsigned char *) NULL;
+  backsafe = NULL;
   win = 0;
 
   // Initially we don't know yet which display we are bound to until create()
@@ -70,8 +71,6 @@ Icon::Icon (Configuration *loaded_conf, int iconidx)
 
 Icon::~Icon (void)
 {
-  // Deallocate all X11 realted resources
-  destroy();
 }
 
 int Icon::get_iconid()
@@ -221,7 +220,7 @@ Window Icon::create (Display *display)
   return win;
 }
 
-void Icon::destroy(void)
+void Icon::destroy(Display *display)
 {
   // Deallocate resources to terminate the icon
   if (iconMapNone) {
@@ -235,10 +234,8 @@ void Icon::destroy(void)
   if (cursor) {
     XFreeCursor (icon_display, cursor);
   }
-}
 
-void Icon::initialize (Display *display)  // to be removed!
-{
+  XDestroyWindow (display, win);
 }
 
 void Icon::draw(Display *display, XEvent ev)
@@ -251,7 +248,6 @@ void Icon::draw(Display *display, XEvent ev)
   string ficon1 = configuration->get_icon_string (iconid, "icon");
 
   log5 ("drawing icon (name @coords)", ficon1, iconx, icony, iconw, iconh);
-
 
   // Reinforcing the window to stay at the bottom of all windows. From the docs on XLowerWindow...
   // "Lowering a mapped window will generate Expose events on any windows it formerly obscured."

--- a/src/icon.h
+++ b/src/icon.h
@@ -47,9 +47,9 @@ class Icon
 
   int get_iconid();
   bool is_singleton_running (void);
+
   Window create(Display *display);
-  void initialize(Display *display);
-  void destroy(void);
+  void destroy(Display *display);
 
   void draw(Display *display, XEvent ev);
   bool blink_icon(Display *display, XEvent ev);


### PR DESCRIPTION
 o With these changes kdesk creates an object window to receive signals
   and provides a SIGUSR1 to raise a break in the processing loop
   so that the configuration and icons are reloaded dynamically.

 o It needs an extra feature by which the object window is contacted
   directly to send an event so we can send this message from
   unrelated processes - different adress spaces.
