### PR TITLE
Kdesk verbose mode flag

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -102,7 +102,6 @@ bool Background::load (Display *display)
       image = imlib_load_image_without_cache(background_file.c_str());
       if (!image) {
 	log1 ("error loading background", background_file);
-	cout << "error loading background image:" << background_file << endl;
       }
       else {
 	// Prepare imlib2 drawing spaces

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -32,7 +32,6 @@ bool Configuration::load_conf(const char *filename)
 
   stat (filename, &file_status);
   if (!S_ISREG(file_status.st_mode)) {
-      cout << "not a file" << endl;
       return false;
     }
 

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -478,7 +478,6 @@ bool Desktop::send_signal (Display *display, const char *signalName, char *messa
 
   if (!wsig && !(wsig=find_kdesk_control_window(display))) {
     // Kdesk control window cannot be found, most likely Kdesk is not running.
-    cout << "Could not find Kdesk control window - perhaps it is not running on this Display?" << endl;
     return false;
   }
 


### PR DESCRIPTION
- By default kdesk will be silent unless the -v (verbose) is provided
- On debug builds all log statements will work as they do now
- There is a minor problem with sound - libmpg123 has hardcoded fprintf's to stderr
