### PR TITLE
Automatic icon positioning

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,12 +23,15 @@ debug:
 	make all DEBUGGING="-ggdb -O3 -DDEBUG"
 
 # the linkage
-$(TARGET): main.o icon.o background.o configuration.o desktop.o sound.o ssaver.o
+$(TARGET): main.o icon.o grid.o background.o configuration.o desktop.o sound.o ssaver.o
 	g++ $(LIBS) $^ -o $(TARGET)
 
 # the compilation
-icon.o: icon.cpp icon.h logging.h configuration.h
+icon.o: icon.cpp icon.h logging.h configuration.h grid.h
 	g++ -c $(DEBUGGING) $(XFTINC) icon.cpp
+
+grid.o: grid.cpp grid.h
+	g++ -c $(DEBUGGING) $(XFTINC) grid.cpp
 
 main.o: main.cpp main.h configuration.h logging.h version.h ssaver.h
 	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) main.cpp
@@ -39,7 +42,7 @@ background.o: background.cpp logging.h sound.h
 configuration.o: configuration.cpp configuration.h logging.h main.h
 	g++ -c $(DEBUGGING) configuration.cpp
 
-desktop.o: desktop.cpp desktop.h logging.h configuration.h sn_callbacks.cpp sound.h
+desktop.o: desktop.cpp desktop.h logging.h configuration.h sn_callbacks.cpp sound.h grid.h
 	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) desktop.cpp
 
 sound.o: sound.cpp sound.h

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -164,7 +164,7 @@ bool Configuration::load_conf(const char *filename)
 	configuration["iconhook"] = value;
       }
     }
- 
+
   ifile.close();
   return true;
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -12,7 +12,7 @@
 #include <map>
 #include <vector>
 
-#define MAX_ICONS 12
+#define MAX_ICONS 32
 
 class Configuration
 {
@@ -36,5 +36,5 @@ class Configuration
   unsigned int get_config_int(std::string item);
   std::string get_icon_string(int iconid, std::string key);
   int get_icon_int(int iconid, std::string key);
-  int get_numicons(void);  
+  int get_numicons(void);
 };

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -21,6 +21,8 @@
 #define KDESK_SIGNAL_ICON_ALERT   "KSIG_ICON_ALERT"
 #define KDESK_BLUR_DESKTOP        "KSIG_BLUR_DESKTOP"
 
+class IconGrid;
+
 class Desktop
 {
  private:
@@ -28,6 +30,7 @@ class Desktop
   Background *pbground;
   bool initialized;
   std::map <Window, Icon *> iconHandlers;
+  IconGrid *icon_grid;
   SnDisplay *sn_display;
   SnLauncherContext *sn_context;
   Configuration *pconf;

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1,0 +1,73 @@
+//
+// grid.cpp
+//
+// Copyright (C) 2013-2014 Kano Computing Ltd.
+// License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+//
+
+#include "grid.h"
+
+/* IconGrid */
+IconGrid::IconGrid(Display *display)
+{
+  int screen_num = DefaultScreen(display);
+  int w = DisplayWidth(display, screen_num);
+  int h = DisplayHeight(display, screen_num);
+
+  width = w / ICON_W;
+  if (width > MAX_FIELDS_X)
+    width = MAX_FIELDS_X;
+
+  height = (h - MARGIN_TOP - MARGIN_BOTTOM) / ICON_H;
+
+  start_x = w/2 - (width * (ICON_W + HORZ_SPC))/2;
+  start_y = h - MARGIN_BOTTOM;
+}
+
+IconGrid::~IconGrid()
+{
+  /* Nothing here yet */
+}
+
+
+bool IconGrid::is_place_used(int x, int y)
+{
+  for (coord_list_t::iterator it = used_fields.begin();
+      it != used_fields.end(); it++) {
+    if (it->first == x && it->second == y) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void IconGrid::get_real_position(int field_x, int field_y,
+                                 int *real_x, int *real_y)
+{
+  *real_x = start_x + field_x * (ICON_W + HORZ_SPC);
+  *real_y = start_y - (1 + field_y) * (ICON_H + VERT_SPC);
+  used_fields.push_back(std::pair<int, int>(field_x, field_y));
+}
+
+bool IconGrid::request_position(int field_hint_x, int field_hint_y,
+                               int *x, int *y)
+{
+  if (field_hint_x >= 0 && field_hint_x < width &&
+      field_hint_y >= 0 && field_hint_y < height) {
+    if (!is_place_used(field_hint_x, field_hint_y)) {
+      get_real_position(field_hint_x, field_hint_y, x, y);
+      return true;
+    }
+  }
+
+  /* find a free spot */
+  for (int iy = 0; iy < height; iy++) {
+    for (int ix = 0; ix < width; ix++) {
+      if (!is_place_used(ix, iy)) {
+        get_real_position(ix, iy, x, y);
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/grid.h
+++ b/src/grid.h
@@ -1,0 +1,46 @@
+//
+// grid.h
+//
+// Copyright (C) 2013-2014 Kano Computing Ltd.
+// License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+//
+//
+
+#include <vector>
+#include <string>
+
+#include <X11/Xlib.h>
+#include <X11/Xft/Xft.h>
+
+class IconGrid
+{
+  private:
+    static const int ICON_W = 128;
+    static const int ICON_H = 128;
+
+    static const int VERT_SPC = 10;
+    static const int HORZ_SPC = 10;
+
+    static const int MARGIN_BOTTOM = 84;
+    static const int MARGIN_TOP = 50;
+
+    static const int MAX_FIELDS_X = 7;
+
+    typedef std::vector<std::pair<int, int> > coord_list_t;
+
+    int width;
+    int height;
+    coord_list_t used_fields;
+
+    int start_x;
+    int start_y;
+
+    bool is_place_used(int x, int y);
+    void get_real_position(int field_x, int field_y, int *real_x, int *real_y);
+
+  public:
+    IconGrid(Display *display);
+    ~IconGrid(void);
+
+    bool request_position(int field_hint_x, int field_hint_y, int *x, int *y);
+};

--- a/src/icon.h
+++ b/src/icon.h
@@ -20,6 +20,8 @@
 // 
 #define DEFAULT_ICON_CURSOR XC_hand1
 
+class IconGrid;
+
 class Icon
 {
  private:
@@ -59,7 +61,7 @@ class Icon
   int get_icon_horizontal_placement (int image_width);
   bool is_singleton_running (void);
 
-  Window create(Display *display);
+  Window create(Display *display, IconGrid *icon_grid);
   void destroy(Display *display);
 
   void draw(Display *display, XEvent ev);


### PR DESCRIPTION
This commit introduces automatic icon positioning on a grid into kdesk.

You can turn it on by putting the following into the icon config:

Relative-to: grid
X: `grid-location-hint`
Y: `grid-location-hint`

kdesk will try to satisfy the field based on your location hints, but in cases it cannot, it will position the icon automatically. In case you don't care about the position of the icon at all, just set X and Y to 'auto'.

Note that the attributes Width and Height are IGNORED when the icon is put into the grid! Both of them are forced to 128, so the grid is uniform.

Related to: https://github.com/KanoComputing/peldins/issues/716

**TODO:** We might want to rename the attribute Relative-to to something different in the future.

cc @skarbat @alex5imon 
