### PR TITLE
Fixing kdesk -a, icon hook signals were not being populated.

### DIFF
--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -93,26 +93,28 @@ bool Desktop::create_icons (Display *display)
 	pos = pconf->get_icon_string(nicon, "relative-to");
 	x = pconf->get_icon_string(nicon, "x");
 	y = pconf->get_icon_string(nicon, "y");
-	if (pos == "grid" && x != "auto" && y != "auto")
+	if (pos == "grid" && x != "auto" && y != "auto") {
 	  /* Has hints, skip in the second pass */
-	  if (pass > 1)
+	  if (pass == 1)
 	    continue;
-	else
+	}
+	else {
 	  /* No hints, skip in the first pass */
 	  if (pass == 0)
 	    continue;
+	}
 
         Icon *pico = new Icon(pconf, nicon);
         Window wicon = pico->create(display, icon_grid);
         if (wicon) {
-  	XEvent emptyev;
-  	iconHandlers[wicon] = pico;
-  	pico->draw(display, emptyev);
-  	numicons++;
+	  XEvent emptyev;
+	  iconHandlers[wicon] = pico;
+	  pico->draw(display, emptyev);
+	  numicons++;
         }
         else {
-  	log1 ("Warning: error creating icon", pconf->get_icon_string(nicon, "filename"));
-  	delete pico;
+	  log1 ("Warning: error creating icon", pconf->get_icon_string(nicon, "filename"));
+	  delete pico;
         }
       }
    }


### PR DESCRIPTION
- Embracing 2-nested if blocks in curly braces
- Fixing an "if pass" statement that would never be true (correct me if i'm wrong)
- This fixes kdesk hook signals, but the grid I think needs more work, some grid icons are overlapped
  (using the caption attibute to see their positioning on the desktop)
