### PR TITLE
Support for automatic Kdesk icon hooks (startup and refresh)

### DIFF
--- a/src/desktop.h
+++ b/src/desktop.h
@@ -46,7 +46,7 @@ class Desktop
 
   void initialize(Background *p);
   bool create_icons (Display *display);
-  Icon *find_icon_filename (char *icon_filename);
+  Icon *find_icon_name (char *icon_name);
   bool destroy_icons (Display *display);
 
   bool notify_startup_load (Display *display, int iconid, Time time);
@@ -58,5 +58,6 @@ class Desktop
   Window find_kdesk_control_window (Display *display);
   bool process_and_dispatch(Display *display);
   bool send_signal (Display *display, const char *signalName, char *message);
+  bool call_icon_hook (Display *display, XEvent ev, std::string hookscript, Icon *pico_hook);
   bool finalize(void);
 };

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -101,6 +101,15 @@ std::string Icon::get_icon_filename(void)
   return configuration->get_icon_string (iconid, "filename");
 }
 
+std::string Icon::get_icon_name(void)
+{
+  // returns icon name without the LNK extension
+  string filename = get_icon_filename();
+
+  // FIXME: Upper/lowercase names for the extension
+  return filename.erase (filename.rfind(".lnk"), std::string::npos);
+}
+
 void Icon::set_caption (char *new_caption)
 {
   caption = new_caption;

--- a/src/icon.h
+++ b/src/icon.h
@@ -58,6 +58,7 @@ class Icon
 
   int get_iconid(void);
   std::string get_icon_filename(void);
+  std::string get_icon_name(void);
   int get_icon_horizontal_placement (int image_width);
   bool is_singleton_running (void);
 


### PR DESCRIPTION
- provide for automatic icon hooks upon kdesk startup and refresh signals
- reorganized hook code
- support for case insensitive icon names to invoke hooks
- improved search algorithm to find icons during hook invocation
- improved effiency: icon is only redrawn if hook changes at least 1 attribute
