### PR TITLE
Desktop blur of applications in one execution step

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -305,3 +305,51 @@ int Background::refresh_background(Display *display)
 
   return nchildren_return;
 }
+
+bool Background::is_blurred(Display *display)
+{
+  int screen = DefaultScreen (display);
+  Window root = RootWindow (display, screen);
+  Window root_return, parent_return, *children_return=NULL, *subchildren_return=NULL;
+  unsigned int nchildren_return=0, nsubchildren_return=0;
+  bool found = false;
+
+  // Enumerate all top level windows in search for the Kdesk's blurred window
+  if (XQueryTree(display, root, &root_return, &parent_return, &children_return, &nchildren_return))
+    {
+      char *windowname=NULL;
+      for (int i=0; i < nchildren_return; i++)
+	{
+	  if (XFetchName (display, children_return[i], &windowname)) {
+	    if (!strncmp (windowname, "KdeskBlur", strlen ("KdeskBlur"))) {
+	      found = true;
+	      XFree (windowname);
+	      break;
+	    }
+	  }
+
+	  XQueryTree (display, children_return[i], &root_return, &parent_return, &subchildren_return, &nsubchildren_return);
+
+	  for (int k=nsubchildren_return-1; k>=0; k--) {
+	    if (XFetchName (display, subchildren_return[k], &windowname)) {
+	      if (!strncmp (windowname, "KdeskBlur", strlen ("KdeskBlur"))) {
+		found=true;
+		XFree (windowname);
+		break;
+	      }
+	    }
+	  }
+
+	}
+    }
+
+  if (children_return) {
+    XFree(children_return);
+  }
+
+  if (subchildren_return) {
+    XFree(children_return);
+  }
+
+  return found;
+}

--- a/src/background.h
+++ b/src/background.h
@@ -30,6 +30,7 @@ class Background
   bool load (Display *display);
   bool draw (Display *display);
   bool blur(Display *display);
+  static bool is_blurred(Display *display);
   int refresh_background(Display *display);
 
 };

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -261,7 +261,7 @@ bool Desktop::process_and_dispatch(Display *display)
 	      else {
 		log ("Desktop or Background class not initialized - cannot blur desktop");
 	      }
-	      return true;
+	      return false;
 	    }
 	    else if ((Atom) ev.xclient.data.l[0] == atom_icon_alert) {
 


### PR DESCRIPTION
- the -b parameter now needs a value called the app command line
- upon receiving this command, desktop is blurred, app launched synchronously,
  when the app finishes the desktop is restored to original state.
- example: kdesk -v -b "lxterminal --command=\"/bin/bash -c 'ls -l ; sleep 10'\""
  will popup a lxterminal listing your directory contents for 10 seconds with blurred background
  then quit and return UIX to original colors.
- if a second blur requests comes in, it will unblur the desktop and quit.
