### PR TITLE
Grid icon size defaults to 128x128 but kdeskrc can override them

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -163,6 +163,17 @@ bool Configuration::load_conf(const char *filename)
 	ifile >> value;
 	configuration["iconhook"] = value;
       }
+
+      if (token == "GridWidth:") {
+	ifile >> value;
+	configuration["gridwidth"] = value;
+      }
+
+      if (token == "GridHeight:") {
+	ifile >> value;
+	configuration["gridheight"] = value;
+      }
+
     }
 
   ifile.close();

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -78,7 +78,7 @@ bool Desktop::create_icons (Display *display)
 {
   int nicon=0;
 
-  icon_grid = new IconGrid(display);
+  icon_grid = new IconGrid(display, pconf);
 
   // Create and draw all icons, save a mapping of their window IDs -> handlers
   // so that we can dispatch events to each one in turn later on.

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -5,14 +5,38 @@
 // License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
 //
 
+#include "configuration.h"
 #include "grid.h"
+#include "logging.h"
+
+
+// Static non-const member variable need be defined at file scope
+int IconGrid::ICON_W;
+int IconGrid::ICON_H;
 
 /* IconGrid */
-IconGrid::IconGrid(Display *display)
+IconGrid::IconGrid(Display *display, Configuration *pconf)
 {
   int screen_num = DefaultScreen(display);
   int w = DisplayWidth(display, screen_num);
   int h = DisplayHeight(display, screen_num);
+
+  // Get the grid dimensions from kdeskrc file
+  if (pconf) {
+    ICON_W = pconf->get_config_int("gridwidth");
+    ICON_H = pconf->get_config_int("gridheight");
+  }
+
+  // Or set default values if they're not defined
+  if (!ICON_W) {
+    ICON_W = DEFAULT_GRID_WIDTH;
+  }
+
+  if (!ICON_H) {
+    ICON_H = DEFAULT_GRID_HEIGHT;
+  }
+
+  log2 ("Icon grid width and height", ICON_W, ICON_H);
 
   width = w / ICON_W;
   if (width > MAX_FIELDS_X)

--- a/src/grid.h
+++ b/src/grid.h
@@ -12,12 +12,12 @@
 #include <X11/Xlib.h>
 #include <X11/Xft/Xft.h>
 
+#define DEFAULT_GRID_WIDTH   128
+#define DEFAULT_GRID_HEIGHT  128
+
 class IconGrid
 {
   private:
-    static const int ICON_W = 128;
-    static const int ICON_H = 128;
-
     static const int VERT_SPC = 10;
     static const int HORZ_SPC = 10;
 
@@ -39,8 +39,11 @@ class IconGrid
     void get_real_position(int field_x, int field_y, int *real_x, int *real_y);
 
   public:
-    IconGrid(Display *display);
+    IconGrid(Display *display, Configuration *pconf);
     ~IconGrid(void);
+
+    static int ICON_W;
+    static int ICON_H;
 
     bool request_position(int field_hint_x, int field_hint_y, int *x, int *y);
 };

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -232,8 +232,8 @@ Window Icon::create (Display *display, IconGrid *icon_grid)
   string icon_placement = configuration->get_icon_string(iconid, "relative-to");
   if (icon_placement == "grid") {
     // Grid icons have fixed size
-    iconw = 128;
-    iconh = 128;
+    iconw = icon_grid->ICON_W;
+    iconh = icon_grid->ICON_H;
 
     string iconx_tmp, icony_tmp;
 
@@ -256,6 +256,7 @@ Window Icon::create (Display *display, IconGrid *icon_grid)
       log("No spaces available in the grid!");
       return None;
     }
+
   } else {
     iconx = configuration->get_icon_int (iconid, "x");
     icony = configuration->get_icon_int (iconid, "y");


### PR DESCRIPTION
- The grid object gets a Configuration
- Initial default values set if IconWidht and/or IconHeight not found
- Set new member grid size variables as static at file scope

ping @pazdera 
