### PR TITLE
Fixing blur bug: Icons were not redrawn properly after blur effect

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -12,6 +12,7 @@
 
 #include <cmath>
 #include <memory.h>
+#include <stdlib.h>
 
 #include "configuration.h"
 #include "background.h"
@@ -178,6 +179,7 @@ bool Background::blur(Display *display)
     // revealing the real desktop image, then destroy the XWindow resource.
     XUnmapWindow (display, winblur);
     XDestroyWindow (display, winblur);
+    XFlush (display);
     winblur = 0L;
     success = true;
   }
@@ -298,7 +300,7 @@ int Background::refresh_background(Display *display)
 	  memset(&exppp, 0x00, sizeof(exppp));
 	  exppp.type = Expose;
 	  exppp.xexpose.window = children_return[i];
-	  XSendEvent(display,children_return[i],False,ExposureMask,&exppp);
+	  XSendEvent (display, children_return[i], False, ExposureMask, &exppp);
 	  XFlush(display);
 	}
     }

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -47,6 +47,7 @@ class Desktop
   void initialize(Background *p);
   bool create_icons (Display *display);
   Icon *find_icon_name (char *icon_name);
+  bool redraw_icons (Display *display, bool forceClear);
   bool destroy_icons (Display *display);
 
   bool notify_startup_load (Display *display, int iconid, Time time);

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -383,7 +383,7 @@ void Icon::clear(Display *display, XEvent ev)
   XClearWindow (display, win);
 }
 
-void Icon::draw(Display *display, XEvent ev)
+void Icon::draw(Display *display, XEvent ev, bool fClear)
 {
   Imlib_Color_Modifier colorTrans=NULL;   // used if general icon transparency is requested
   int h=0, w=0, subx=0;
@@ -401,6 +401,12 @@ void Icon::draw(Display *display, XEvent ev)
   //
   XMapWindow(display, win);
   XLowerWindow(display, win);
+
+  if (fClear == true) {
+    // Clear the icon area completely
+    // This is needed when for example the transparent background has changed due to blur effect
+    XClearWindow (display, win);
+  }
 
   // Is there a s Stamp icon? If so, load it now
   if (ficon_stamp.length() > 0) {

--- a/src/icon.h
+++ b/src/icon.h
@@ -65,7 +65,7 @@ class Icon
   Window create(Display *display, IconGrid *icon_grid);
   void destroy(Display *display);
 
-  void draw(Display *display, XEvent ev);
+  void draw(Display *display, XEvent ev, bool fClear);
   void clear(Display *display, XEvent ev);
   bool blink_icon(Display *display, XEvent ev);
   bool unblink_icon(Display *display, XEvent ev);


### PR DESCRIPTION
- Blurred colors were mixed with icon transparency, so an icon
  redraw command is requested after removing the blur
- An additional option to clear the icon area in case the mouse
  pointer is currently drawing the second texture icon

ping @carolineclark 
