### PR TITLE
Provide a new setting to specify subtitle font size

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -53,6 +53,11 @@ bool Configuration::load_conf(const char *filename)
 	ifile >> value;
 	configuration["fontsize"] = value;
       }
+
+      if (token == "SubtitleFontSize:") {
+	ifile >> value;
+	configuration["subtitlefontsize"] = value;
+      }
       
       if (token == "Bold:") {
 	ifile >> value;

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -195,9 +195,15 @@ Window Icon::create (Display *display, IconGrid *icon_grid)
       rc = XftColorAllocName(display, DefaultVisual(display,0), DefaultColormap(display,0), "black", &xftcolor_shadow);
       log1 ("XftColorAllocName bool", rc);
 
+      int subtitle_fontsize = configuration->get_config_int ("subtitlefontsize");
+      if (!subtitle_fontsize) {
+        // Assign a smaller font size
+        subtitle_fontsize = fontsize - DEFAULT_SUBTITLE_FONT_POINT_DECREASE;
+      }
+
       fontsmaller = XftFontOpen (display, DefaultScreen(display),
 				 XFT_FAMILY, XftTypeString, fontname.c_str(),
-				 XFT_SIZE, XftTypeDouble, (float) fontsize - 2,
+				 XFT_SIZE, XftTypeDouble, (float) subtitle_fontsize,
 				 NULL);
       log1 ("creating a smaller font for messages", fontsmaller);
 

--- a/src/icon.h
+++ b/src/icon.h
@@ -20,6 +20,9 @@
 // 
 #define DEFAULT_ICON_CURSOR XC_hand1
 
+// Number of points to decrease the font size for subtitle text in icons
+#define DEFAULT_SUBTITLE_FONT_POINT_DECREASE 6
+
 class IconGrid;
 
 class Icon


### PR DESCRIPTION
- The new key is called "SubtitleFontSize". If it's not defined
  kdesk will provide a font size 6 points smaller than the initial one (FontSize value)
