### PR TITLE
Fixing bug: icon images were not being updated during a refresh

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -194,6 +194,11 @@ bool Configuration::load_conf(const char *filename)
 	configuration["maximizesingleton"] = value;
       }
 
+      if (token == "ImageCacheSize:") {
+	ifile >> value;
+	configuration["imagecachesize"] = value;
+      }
+
     }
 
   ifile.close();

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -360,9 +360,19 @@ void Icon::destroy(Display *display)
     fontsmaller = NULL;
   }
 
+  if (image != NULL) {
+    imlib_context_set_image(image);
+    imlib_free_image_and_decache();
+  }
+
+  if (image_stamp != NULL) {
+    imlib_context_set_image(image_stamp);
+    imlib_free_image_and_decache();
+  }
+
   if (backsafe != NULL) {
     imlib_context_set_image(backsafe);
-    imlib_free_image();
+    imlib_free_image_and_decache();
   }
 
   XDestroyWindow (display, win);
@@ -429,6 +439,14 @@ void Icon::draw(Display *display, XEvent ev, bool fClear)
   if (image != NULL) {
 
     imlib_context_set_image(image);
+
+    // imlib2 stores each image buffer as a sequence of ARGB objects (32 bits per pixel)
+    // this log will emit this size to better profile kdesk's cache size setting.
+    log4 ("Image filename, width, height, and RGBA buffer size",
+          ficon.c_str(),
+          imlib_image_get_width(), imlib_image_get_height(),
+          (imlib_image_get_width() * imlib_image_get_height() * 32) / 8);
+
     w = imlib_image_get_width();
     h = imlib_image_get_height();
     subx = get_icon_horizontal_placement(w);


### PR DESCRIPTION
- Imlib2 cache system was holding previous icons in memory.
- Now we are clearing the cache during a refresh, and enforcing it’s size allocation.
- Forcing the release of fixed icons from memory during each icon class unload
- Also adding a configuration setting for the the cache size so we can control kdesk’s memory working set.
