### PR TITLE
New command line parameter -i to refresh icons only

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -417,7 +417,12 @@ void Configuration::reset(void)
     {
       configuration.erase(it);
     }
+  reset_icons();
+}
 
+void Configuration::reset_icons(void)
+{
+  std::map<string,string>::iterator it;
   for (int c=0; c < numicons; c++) {
     for (it=icons[c].begin(); it != icons[c].end(); ++it)
       {
@@ -428,3 +433,4 @@ void Configuration::reset(void)
   icons.clear();
   numicons = 0;
 }
+

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -31,6 +31,7 @@ class Configuration
   bool parse_icon (const char *directory, std::string fname, int iconid);
   void dump (void);
   void reset(void);
+  void reset_icons(void);
 
   std::string get_config_string(std::string item);
   unsigned int get_config_int(std::string item);

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -18,6 +18,7 @@
 #define KDESK_CONTROL_WINDOW_NAME "KdeskControlWindow"
 #define KDESK_SIGNAL_FINISH       "KSIG_FINISH"
 #define KDESK_SIGNAL_RELOAD       "KSIG_RELOAD"
+#define KDESK_SIGNAL_RELOAD_ICONS "KSIG_RELOAD_ICONS"
 #define KDESK_SIGNAL_ICON_ALERT   "KSIG_ICON_ALERT"
 
 class IconGrid;
@@ -37,7 +38,7 @@ class Desktop
   bool finish;
   static int error_trap_depth;
   int numicons;
-  Atom atom_finish, atom_reload, atom_icon_alert;
+  Atom atom_finish, atom_reload, atom_reload_icons, atom_icon_alert;
 
  public:
   Desktop(void);
@@ -48,6 +49,7 @@ class Desktop
   Icon *find_icon_name (char *icon_name);
   bool redraw_icons (Display *display, bool forceClear);
   bool destroy_icons (Display *display);
+  bool reload_icons (Display *display);
 
   bool notify_startup_load (Display *display, int iconid, Time time);
   bool notify_startup_ready (Display *display);

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -67,8 +67,21 @@ bool IconGrid::is_place_used(int x, int y)
   return false;
 }
 
+bool IconGrid::free_space_used(int x, int y)
+{
+  for (coord_list_t::iterator it = used_fields.begin();
+      it != used_fields.end(); it++) {
+
+    if (it->first == x && it->second == y) {
+      used_fields.erase(it);
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IconGrid::get_real_position(int field_x, int field_y,
-                                 int *real_x, int *real_y)
+                                 int *real_x, int *real_y, int *gridx, int *gridy)
 {
   *real_x = start_x + field_x * (ICON_W + HORZ_SPC);
   *real_y = start_y - (1 + field_y) * (ICON_H + VERT_SPC);
@@ -80,18 +93,20 @@ bool IconGrid::get_real_position(int field_x, int field_y,
     return false;
   }
   else {
+    if (gridx) *gridx = field_x;
+    if (gridy) *gridy = field_y;
     used_fields.push_back(std::pair<int, int>(field_x, field_y));
     return true;
   }
 }
 
 bool IconGrid::request_position(int field_hint_x, int field_hint_y,
-                               int *x, int *y)
+                                int *x, int *y, int *gridx, int *gridy)
 {
   if (field_hint_x >= 0 && field_hint_x < width &&
       field_hint_y >= 0 && field_hint_y < height) {
     if (!is_place_used(field_hint_x, field_hint_y)) {
-      return (get_real_position(field_hint_x, field_hint_y, x, y));
+      return (get_real_position(field_hint_x, field_hint_y, x, y, gridx, gridy));
     }
   }
 
@@ -99,7 +114,7 @@ bool IconGrid::request_position(int field_hint_x, int field_hint_y,
   for (int iy = 0; iy < height; iy++) {
     for (int ix = 0; ix < width; ix++) {
       if (!is_place_used(ix, iy)) {
-        return (get_real_position(ix, iy, x, y));
+        return (get_real_position(ix, iy, x, y, gridx, gridy));
       }
     }
   }

--- a/src/grid.h
+++ b/src/grid.h
@@ -36,7 +36,7 @@ class IconGrid
     int start_y;
 
     bool is_place_used(int x, int y);
-    bool get_real_position(int field_x, int field_y, int *real_x, int *real_y);
+    bool get_real_position(int field_x, int field_y, int *real_x, int *real_y, int *gridx, int *gridy);
 
   public:
     IconGrid(Display *display, Configuration *pconf);
@@ -47,5 +47,6 @@ class IconGrid
 
     bool grid_full;
 
-    bool request_position(int field_hint_x, int field_hint_y, int *x, int *y);
+    bool request_position(int field_hint_x, int field_hint_y, int *x, int *y, int *gridx, int *gridy);
+    bool free_space_used(int x, int y);
 };

--- a/src/icon.h
+++ b/src/icon.h
@@ -31,10 +31,13 @@ class Icon
   Configuration *configuration;
   Display *icon_display;
   Window win;
+  IconGrid *pgrid;
   int iconx, icony, iconw, iconh;
   int shadowx, shadowy;
   int icontitlegap;
   int transparency_value;
+  bool is_grid;
+  int gridx, gridy;
   Cursor cursor;
   int cursor_id;
   Imlib_Image image, image_stamp;
@@ -47,6 +50,7 @@ class Icon
   XftDraw *xftdraw1;
   XftColor xftcolor, xftcolor_shadow;
   unsigned char *iconMapNone, *iconMapGlow, *iconMapTransparency;
+  std::string filename;
   std::string ficon;
   std::string ficon_hover;
   std::string ficon_stamp;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ static Desktop dsk;
 // local function prototypes
 void signal_callback_handler(int signum);
 void reload_configuration (Display *display);
+void reload_icons (Display *display);
 void trigger_icon_hook (Display *display, char *message);
 void finish_kdesk (Display *display);
 
@@ -75,6 +76,13 @@ void reload_configuration (Display *display)
   return;
 }
 
+void reload_icons (Display *display)
+{
+  log ("Reloading kdesk configuration");
+  dsk.send_signal (display, KDESK_SIGNAL_RELOAD_ICONS, NULL);
+  return;
+}
+
 void trigger_icon_hook (Display *display, char *message)
 {
   log ("Trigger an icon hook signal");
@@ -100,7 +108,7 @@ int main(int argc, char *argv[])
   int c;
 
   // Collect command-line parameters
-  while ((c = getopt(argc, argv, "?htwra:vq")) != EOF)
+  while ((c = getopt(argc, argv, "?htwria:vq")) != EOF)
     {
       switch (c)
         {
@@ -112,6 +120,7 @@ int main(int argc, char *argv[])
 	  cout << " -t test mode, read configuration files and exit"<< endl;
 	  cout << " -w set desktop wallpaper and exit" << endl;
 	  cout << " -r refresh configuration and exit" << endl;
+	  cout << " -i refresh desktop icons only and exit" << endl;
 	  cout << " -q query if kdesk is running on the current desktop (rc 0 running, nonzero otherwise)" << endl;
 	  cout << " -a send an icon hook alert" << endl << endl;
 	  exit (1);
@@ -139,6 +148,19 @@ int main(int argc, char *argv[])
 
 	  kprintf ("Sending a refresh signal to Kdesk\n");
 	  reload_configuration(display);
+	  XCloseDisplay(display);
+	  exit (0);
+
+	case 'i':
+	  display = XOpenDisplay(display_name);
+	  if (!display) {
+	    kprintf ("Could not connect to the XServer\n");
+	    kprintf ("Is the DISPLAY variable correctly set?\n\n");
+	    exit (1);
+	  }
+
+	  kprintf ("Sending an icon refresh signal to Kdesk\n");
+	  reload_icons(display);
 	  XCloseDisplay(display);
 	  exit (0);
 


### PR DESCRIPTION
- Icon lnk files added/removed from kdesk directories are immediately updated,
  No hooks are being called, thus reducing UI response time.
- Unaffected icons are not redrawn, this removes the visual flickering effect.
- The dump file is updated to account for the new icon counters.
