### PR TITLE
fix for kdesk -i randomly rendering icons incorrectly

### DIFF
--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -268,12 +268,18 @@ bool Desktop::reload_icons (Display *display)
           if (it->second != NULL) {
             if (!strcasecmp (icon_filename.c_str(), it->second->get_icon_filename().c_str())) {
               found=true;
+
+              // update the iconid as reported from the configurator,
+              // as they have most probably been rearranged in the preceding "remove" loop
+              it->second->set_iconid(nicon);
             }
           }
         }
       
       if (!found) {
         // create a new icon handler and add it to the desktop
+        log2 ("adding new icon to desktop (name, id)", icon_filename, nicon);
+
         Icon *pico = new Icon(pconf, nicon);
         Window wicon = pico->create(display, icon_grid);
         if (wicon) {

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -104,6 +104,11 @@ int Icon::get_iconid(void)
   return iconid;
 }
 
+int Icon::set_iconid(int iconidx)
+{
+  iconid = iconidx;
+}
+
 string Icon::get_appid(void)
 {
   string appid = configuration->get_icon_string (iconid, "appid");

--- a/src/icon.h
+++ b/src/icon.h
@@ -64,6 +64,7 @@ class Icon
   virtual ~Icon (void);
 
   int get_iconid(void);
+  int set_iconid(int iconidx);
   std::string get_appid(void);
   std::string get_icon_filename(void);
   std::string get_icon_name(void);


### PR DESCRIPTION
- when rearranging the new icon list, the numeric index id's needs to be updated.
  this was causing erratic data being collected from the icons.
