### PR TITLE
Fixing the metrics file accross logoff/logon

### DIFF
--- a/src/desktop.h
+++ b/src/desktop.h
@@ -62,6 +62,7 @@ class Desktop
   bool send_signal (Display *display, const char *signalName, char *message);
   bool call_icon_hook (Display *display, XEvent ev, std::string hookscript, Icon *pico_hook);
   bool finalize(void);
+  bool get_metrics_filename(Display *display, char *chfilename, int size);
   bool dump_metrics (Display *display);
 
 };


### PR DESCRIPTION
- When logging off and logon again, the metrics file
  was stuck with the previous user permissions and hence was never
  updated again. This change fixes the problem.
