### PR TITLE
kdesk-hourglass provides a new API which accepts a command line

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+
+kdesk (1.1-9) unstable; urgency=low
+
+  * kdesk-hourglass provides a new API based on the app command line only
+
 kdesk (1.1-8) unstable; urgency=low
 
   * kdesk now maintains a file with the number of icons on the desktop

--- a/src/libkdesk-hourglass/kdesk-hourglass.h
+++ b/src/libkdesk-hourglass/kdesk-hourglass.h
@@ -17,4 +17,10 @@ void kdesk_hourglass_start(char *appname);
 extern "C"
 #endif
 
+void kdesk_hourglass_start_appcmd(char *cmdline);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+
 void kdesk_hourglass_end(void);

--- a/src/libkdesk-hourglass/python/hourglass.py
+++ b/src/libkdesk-hourglass/python/hourglass.py
@@ -17,5 +17,9 @@ def hourglass_start(appname):
     c_appname=ctypes.c_char_p(appname)
     kdesk_hourglass_lib.kdesk_hourglass_start(c_appname)
 
+def hourglass_start_appcmd(cmdline):
+    c_cmdline=ctypes.c_char_p(cmdline)
+    kdesk_hourglass_lib.kdesk_hourglass_start_appcmd(c_cmdline)
+
 def hourglass_end():
     kdesk_hourglass_lib.kdesk_hourglass_end()

--- a/src/libkdesk-hourglass/testmodule.py
+++ b/src/libkdesk-hourglass/testmodule.py
@@ -8,23 +8,30 @@
 # A python test app to load and call the kdesk-hourglass dynamic library
 #
 
-from kdesk.hourglass import hourglass_start, hourglass_end
+from kdesk.hourglass import hourglass_start, hourglass_start_appcmd, hourglass_end
 import os
 import sys
 import time
 
 # Application to test for startup hourglass
-app='/usr/bin/xcalc &'
+app='/usr/bin/xcalc'
 appname='xcalc'
 
+# testing the appname API
 hourglass_start(appname)
 rc = os.system(app)
 if (rc!=0):
     hourglass_end()
     sys.exit(1)
 
-print 'doing other tasks...'
-time.sleep(5)
+time.sleep(1)
 
+# testing the cmdline API
+hourglass_start_appcmd(app)
+rc = os.system(app)
+if (rc!=0):
+    hourglass_end()
+    sys.exit(1)
+    
 print 'byebye!'
 sys.exit(rc)


### PR DESCRIPTION
- For those clients that want to hourglass an app for which
  the application name is not known in advance.
- Accepts the binary name of the program or the full pathname
  which will be stripped of automatically.
