### PR TITLE
Adding 2 new flags in kdeskrc to define margin (gap) between icons

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -104,6 +104,16 @@ bool Configuration::load_conf(const char *filename)
 	configuration["icontitlegap"] = value;
       }
 
+      if (token == "IconGapHorz:") {
+	ifile >> value;
+	configuration["icongaphorz"] = value;
+      }
+
+      if (token == "IconGapVert:") {
+	ifile >> value;
+	configuration["icongapvert"] = value;
+      }
+
       if (token == "Transparency:") {
 	ifile >> value;
 	configuration["transparency"] = value;

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -25,8 +25,26 @@ IconGrid::IconGrid(Display *display, Configuration *pconf)
 
   // Get the grid dimensions from kdeskrc file
   if (pconf) {
-    ICON_W = pconf->get_config_int("gridwidth");
-    ICON_H = pconf->get_config_int("gridheight");
+
+      // this is the blank, unsensitive empty space beween icons, horizontally and vertically.
+      int horz_gap=pconf->get_config_int("icongaphorz");
+      if (horz_gap) {
+          HORZ_SPC=horz_gap;
+      }
+      else {
+          HORZ_SPC=DEFAULT_ICON_HORZ_SPACE;
+      }
+
+      int vert_gap=pconf->get_config_int("icongapvert");
+      if (vert_gap) {
+          VERT_SPC=vert_gap;
+      }
+      else {
+          VERT_SPC=DEFAULT_ICON_VERT_SPACE;
+      }
+      
+      ICON_W = pconf->get_config_int("gridwidth");
+      ICON_H = pconf->get_config_int("gridheight");
   }
 
   // Or set default values if they're not defined
@@ -40,13 +58,17 @@ IconGrid::IconGrid(Display *display, Configuration *pconf)
 
   log2 ("Icon grid width and height", ICON_W, ICON_H);
 
-  width = w / ICON_W;
+  // Take into account the space needed for the icon and the empty margin
+  width = w / (ICON_W + HORZ_SPC);
   if (width > MAX_FIELDS_X)
     width = MAX_FIELDS_X;
 
   height = (h - MARGIN_TOP - MARGIN_BOTTOM) / ICON_H;
 
-  start_x = w/2 - (width * (ICON_W + HORZ_SPC))/2;
+  // FIXME: + ((HORZ_SPC/2) - 2, this is needed to avoid overall displacement to the left
+  // I believe the gap applies to all the icons except one, but needs clarification.
+  start_x = w/2 - ((width * (ICON_W + HORZ_SPC)) / 2) + ((HORZ_SPC/2) - 2);
+
   start_y = h - MARGIN_BOTTOM;
 }
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -15,11 +15,14 @@
 #define DEFAULT_GRID_WIDTH   128
 #define DEFAULT_GRID_HEIGHT  128
 
+#define DEFAULT_ICON_HORZ_SPACE   50
+#define DEFAULT_ICON_VERT_SPACE   25
+
 class IconGrid
 {
   private:
-    static const int VERT_SPC = 10;
-    static const int HORZ_SPC = 10;
+    int VERT_SPC;
+    int HORZ_SPC;
 
     static const int MARGIN_BOTTOM = 84;
     static const int MARGIN_TOP = 50;


### PR DESCRIPTION
- This space, vertical and horizontal, was hardcoded in the grid code,
  now it has defaults and can be overriden in kdeskrc file.
- There is a deviation of about 2 pixels on 1280 screen, FIXME commented.
