### PR TITLE
Adding a new package called kdesk debug version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,15 @@
 all: kdesk
 
 kdesk:
-	cd src && make all
+	cd src && make -B
+	cd src && make debug -B
+
 	cd src/kdesk-eglsaver && make all
 	cd src/kdesk-blur && make all
 	cd src/libkdesk-hourglass && make all
 
 debug:
-	cd src && make debug
+	cd src && make debug -B
 	cd src/kdesk-eglsaver && make debug
 	cd src/kdesk-blur && make debug
 	cd src/libkdesk-hourglass && make all

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: libx11-dev, libxft-dev, libimlib2-dev, libstartup-notification0-d
 
 Package: kdesk
 Architecture: any
-Depends: libkdesk-dev (= ${binary:Version}),  ${misc:Depends}, ${shlibs:Depends}, libstartup-notification0, libxss1
+Depends: libkdesk-dev (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libstartup-notification0, libxss1
 Provides: idesk
 Conflicts: idesk
 Replaces: idesk
@@ -24,3 +24,7 @@ Description: Kanux desktop hourglass developer library
  This package contains the library, include file and sample source code
  to provide your applications with an hourglass for desktop lengthy tasks.
 
+Package: kdesk-dbg
+Architecture: any
+Depends: libkdesk-dev (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends}, libstartup-notification0, libxss1
+Description: Kanux desktop icon manager (Debug version)

--- a/debian/kdesk-dbg.install
+++ b/debian/kdesk-dbg.install
@@ -1,0 +1,1 @@
+src/kdesk-dbg /usr/bin

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,10 +17,12 @@ SNINC=-I/usr/include/startup-notification-1.0
 
 TARGET=kdesk
 
+.PHONY: clean
+
 all: $(TARGET)
 
 debug:
-	make all DEBUGGING="-ggdb -O3 -DDEBUG"
+	make all DEBUGGING="-ggdb -O3 -DDEBUG" TARGET=kdesk-dbg
 
 # the linkage
 $(TARGET): main.o icon.o grid.o background.o configuration.o desktop.o sound.o ssaver.o
@@ -50,3 +52,6 @@ sound.o: sound.cpp sound.h
 
 ssaver.o: ssaver.cpp ssaver.h
 	g++ -c $(DEBUGGING) $(XFTINC) $(SNINC) ssaver.cpp
+
+clean:
+	-rm *o kdesk kdesk-dbg

--- a/src/kdesk-blur/Makefile
+++ b/src/kdesk-blur/Makefile
@@ -3,7 +3,7 @@
 #
 
 INCS:=-I../
-LIBS:=-lXft -lImlib2 -lstdc++ -lpthread -lXss
+LIBS:=-lXft -lImlib2 -lstdc++ -lpthread -lXss -lX11
 TARGET=kdesk-blur
 
 all: $(TARGET)


### PR DESCRIPTION
- Main makefile builds both release and debug version binaries
- New package installs kdesk-dbg app
- Added missing x11 lib when linking kdesk-blur
- New makefile rule to clean kdesk built files
