### PR TITLE
Centralizing code to detect user activity in screen saver

### DIFF
--- a/src/kdesk-eglsaver/Makefile
+++ b/src/kdesk-eglsaver/Makefile
@@ -36,8 +36,5 @@ hid.o: hid.cpp hid.h
 $(APP): $(APP).o hid.o
 	gcc -o $@ -Wl,--whole-archive $(APP).o hid.o $(LDFLAGS) -Wl,--no-whole-archive -rdynamic
 
-$(APP).o: $(APP).c bitmap_minecraft.h bitmap_pong.h bitmap_homefolder.h
+$(APP).o: $(APP).c bitmap_minecraft.h bitmap_pong.h bitmap_homefolder.h hid.h
 	gcc $(CFLAGS) $(INCLUDES) -g -c $< -o $@ -Wno-deprecated-declarations
-
-
-

--- a/src/kdesk-eglsaver/hid.h
+++ b/src/kdesk-eglsaver/hid.h
@@ -37,7 +37,7 @@ HID_HANDLE hid_init(int flags);
 #ifdef __cplusplus
 extern "C"
 #endif
-bool hid_is_user_idle (HID_HANDLE hhid);
+bool hid_is_user_idle (HID_HANDLE hhid, int timeout);
 
 #ifdef __cplusplus
 extern "C"

--- a/src/kdesk-eglsaver/kdesk-eglsaver.c
+++ b/src/kdesk-eglsaver/kdesk-eglsaver.c
@@ -403,11 +403,11 @@ static void redraw_scene(CUBE_STATE_T *state)
 static void init_textures(CUBE_STATE_T *state)
 {
 
-  //  TODO: use load_tex_images when bitmap files are provided on the command line
+  // TODO: use load_tex_images when bitmap files are provided on the command line
   // load three texture buffers from files but use them on six OGL|ES texture surfaces
-  //load_tex_images;
+  // load_tex_images;
 
-  //  TODO: use load_tex_images when bitmap files are provided on the command line
+  // load_tex_buffers() use in-memory images compiled into the binary as raw data.
   load_tex_buffers(state);
 
    glGenTextures(6, &state->tex[0]);
@@ -568,7 +568,7 @@ int main ()
         redraw_scene(state);
             
 	// If there is an input event from keyboard or mouse, stop now
-        if (hid_is_user_idle(hid) == true) {
+        if (hid_is_user_idle(hid, 0) == true) {
             terminate=true;
         }
     }


### PR DESCRIPTION
- Code now sits in a separate module easy to integrate to other screensavers.
- Three functions now will help clients work a typical draw loop wih no delay.
- Added robustness with initial load delay, fixes annoying typeahead false positives during SDLC.
