### PR TITLE
Fixing resize of icons to fit in the grid

### DIFF
--- a/src/desktop.h
+++ b/src/desktop.h
@@ -34,6 +34,7 @@ class Desktop
   bool finish;
   static int error_trap_depth;
   int numicons;
+  int cache_size;
   Atom atom_finish, atom_reload, atom_reload_icons, atom_icon_alert;
 
  public:

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -532,8 +532,14 @@ void Icon::draw(Display *display, XEvent ev, bool fClear)
     // Draw the icon on the surface window, default is top-left.
     if (configuration->get_icon_string(iconid, "relative-to") == "grid") {
       // If it's inside a grid we will position it horizontally centered, and to the bottom.
-      int gridx = (configuration->get_config_int ("gridwidth") - w) / 2;
-      int gridy = configuration->get_config_int ("gridheight") - h;
+        int gridx = (configuration->get_config_int ("gridwidth") > w ? 
+                     (configuration->get_config_int ("gridwidth") - w) / 2 : 0);
+
+        int gridy = (configuration->get_config_int ("gridheight") > h ?
+                     configuration->get_config_int ("gridheight") - h : 0);
+
+      log2 ("XXX and YYY", gridx, gridy);
+
       imlib_render_image_on_drawable (gridx, gridy);
     } 
     else {   

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -538,8 +538,6 @@ void Icon::draw(Display *display, XEvent ev, bool fClear)
         int gridy = (configuration->get_config_int ("gridheight") > h ?
                      configuration->get_config_int ("gridheight") - h : 0);
 
-      log2 ("XXX and YYY", gridx, gridy);
-
       imlib_render_image_on_drawable (gridx, gridy);
     } 
     else {   

--- a/src/libkdesk-hourglass/kdesk-hourglass.cpp
+++ b/src/libkdesk-hourglass/kdesk-hourglass.cpp
@@ -57,11 +57,6 @@ void kdesk_hourglass_end()
 void _start_launcher_(char *appname, char *cmdline)
 {
     Time xlib_time=0L;
-
-    display=XOpenDisplay(NULL);
-    if (!display) {
-        return;
-    }
   
     // sn_notify cannot cope with appname being NULL, but he likes it as an empty string.
     if (!appname) {


### PR DESCRIPTION
 * If the requested icon size is larger than that of the grid,
   the values are corrected to fit properly
 * This bug would raise a runtime X11 error at XShmGetImage because of a negative value.