### PR TITLE
Fix problem with wallpaper image filenames with spaces

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -80,13 +80,13 @@ bool Configuration::load_conf(const char *filename)
       }
 
       if (token == "Background.File-4-3:") {
-	ifile >> value;
-	configuration["background.file-4-3"] = value;
+          value = get_spaced_value();
+          configuration["background.file-4-3"] = value;
       }
 
       if (token == "Background.File-16-9:") {
-	ifile >> value;
-	configuration["background.file-16-9"] = value;
+          value = get_spaced_value();
+          configuration["background.file-16-9"] = value;
       }
 
       if (token == "ClickDelay:") {
@@ -165,8 +165,8 @@ bool Configuration::load_conf(const char *filename)
       }
 
       if (token == "Background.File-medium:") {
-	ifile >> value;
-	configuration["background.file-medium"] = value;
+          value = get_spaced_value();
+          configuration["background.file-medium"] = value;
       }
 
       if (token == "MouseHoverIcon:") {
@@ -399,6 +399,20 @@ int Configuration::get_icon_int(int iconid, std::string key)
 int Configuration::get_numicons(void)
 {
   return numicons;
+}
+
+std::string Configuration::get_spaced_value(void)
+{
+    std::string value;
+
+    // get the value until end of line
+    std::getline (ifile, value);
+
+    // trim leading and trailing spaces
+    value.erase (0, value.find_first_not_of (' '));
+    value.erase (value.find_last_not_of (' ') + 1);
+
+    return value;
 }
 
 void Configuration::dump()

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -32,6 +32,7 @@ class Configuration
   void dump (void);
   void reset(void);
   void reset_icons(void);
+  std::string get_spaced_value(void);
 
   std::string get_config_string(std::string item);
   unsigned int get_config_int(std::string item);


### PR DESCRIPTION
 * When parsing the configuration files, bitmaps for wallpapers
   with spaces in their pathnames would not be found. This changeset fixes it.