### PR TITLE
Fixing the way by which the icons are being reloaded

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -474,27 +474,20 @@ void Configuration::dump()
 
 void Configuration::reset(void)
 {
-  std::map<string,string>::iterator it;
-  for (it=configuration.begin(); it != configuration.end(); ++it)
-    {
-      configuration.erase(it);
-    }
-
-  configuration.clear();
-  reset_icons();
+    configuration.erase(configuration.begin(), configuration.end());
+    configuration.clear();
+    reset_icons();
 }
 
 void Configuration::reset_icons(void)
 {
-  std::map<string,string>::iterator it;
-  for (int c=0; c < numicons; c++) {
-    for (it=icons[c].begin(); it != icons[c].end(); ++it)
-      {
-	icons[c].erase (it);
-      }
-  }
+    std::map<string,string>::iterator it;
 
-  icons.clear();
-  numicons = 0;
+    for (int c=0; c < numicons; c++) {
+        icons[c].erase(icons[c].begin(), icons[c].end());
+    }
+
+    icons.clear();
+    numicons=0;
 }
 

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -474,8 +474,14 @@ void Configuration::dump()
 
 void Configuration::reset(void)
 {
-    configuration.erase(configuration.begin(), configuration.end());
-    configuration.clear();
+    try {
+        configuration.erase(configuration.begin(), configuration.end());
+        configuration.clear();
+    }
+    catch (exception &e) {
+        ;
+    }
+
     reset_icons();
 }
 
@@ -483,11 +489,17 @@ void Configuration::reset_icons(void)
 {
     std::map<string,string>::iterator it;
 
-    for (int c=0; c < numicons; c++) {
-        icons[c].erase(icons[c].begin(), icons[c].end());
+    try {
+        for (int c=0; c < numicons; c++) {
+            icons[c].erase(icons[c].begin(), icons[c].end());
+        }
+
+        icons.clear();
+    }
+    catch (exception &e) {
+        ;
     }
 
-    icons.clear();
     numicons=0;
 }
 

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -195,13 +195,14 @@ bool Desktop::destroy_icons (Display *display)
       // events which we are not dealing with anymore, they are defunct.
       // This is the case with hover effects when the mouse is over them during refresh.
       if (it->second) {
-	it->second->destroy(display);
-	delete it->second;
+          it->second->destroy(display);
+          delete it->second;
+          log1 ("deleting", it->first);
       }
-      iconHandlers.erase(it);
     }
 
   // Then empty the list of icon handlers
+  iconHandlers.erase(iconHandlers.begin(), iconHandlers.end());
   iconHandlers.clear();
   numicons = 0;
 

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -369,6 +369,8 @@ void Icon::destroy(Display *display)
     xftdraw1 = NULL;
   }
 
+  XDestroyWindow (display, win);
+
   if (font) {
     XftFontClose(display, font);
     font = NULL;
@@ -398,8 +400,6 @@ void Icon::destroy(Display *display)
   if (is_grid == true) {
     pgrid->free_space_used (gridx, gridy);
   }
-
-  XDestroyWindow (display, win);
 }
 
 int Icon::get_icon_horizontal_placement (int image_width)


### PR DESCRIPTION
 * Changing the iterator increment loop to remove configuration keys
 * There is still a hidden bug as it eventually crashes with:
    throwing an instance of 'std::out_of_range'
    what():  basic_string::erase