### PR TITLE
Fixing random kdesk termination after several "kdesk -r" refreshes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Team Kano <dev@kano.me>
 Section: x11
 Priority: optional
 Standards-Version: 1.1.0
-Build-Depends: libx11-dev, libxft-dev, libimlib2-dev, libstartup-notification0-dev, libxss-dev, libraspberrypi-dev, debhelper (>=9.0.0)
+Build-Depends: libx11-dev, libxft-dev, libimlib2-dev, libstartup-notification0-dev, libxss-dev, libraspberrypi-dev, debhelper (>=9.0.0), g++-4.7
 
 Package: kdesk
 Architecture: any

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,9 @@ LIBS:=-lXft -lImlib2 -lstdc++ -lpthread -lX11 -lXss -L`pwd`/libkdesk-hourglass -
 XFTINC:=-I/usr/include/freetype2
 HOURGLASSINCS= -I`pwd`/libkdesk-hourglass
 
+GPLUSPLUS=g++-4.7
+CFLAGS=-std=c++11
+
 TARGET=kdesk
 
 .PHONY: clean
@@ -19,36 +22,36 @@ TARGET=kdesk
 all: $(TARGET)
 
 debug:
-	make all DEBUGGING="-ggdb -O3 -DDEBUG" TARGET=kdesk-dbg
+	make all DEBUGGING="-ggdb -DDEBUG" TARGET=kdesk-dbg
 
 # the linkage
 $(TARGET): main.o icon.o grid.o background.o configuration.o desktop.o sound.o ssaver.o
-	g++ $(LIBS) $^ -o $(TARGET)
+	$(GPLUSPLUS) $(LIBS) $^ -o $(TARGET)
 
 # the compilation
 icon.o: icon.cpp icon.h logging.h configuration.h grid.h
-	g++ -c $(DEBUGGING) $(XFTINC) icon.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) icon.cpp
 
 grid.o: grid.cpp grid.h
-	g++ -c $(DEBUGGING) $(XFTINC) grid.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) grid.cpp
 
 main.o: main.cpp main.h configuration.h logging.h version.h ssaver.h
-	g++ -c $(DEBUGGING) $(XFTINC) main.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) main.cpp
 
 background.o: background.cpp logging.h sound.h
-	g++ -c $(DEBUGGING) background.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) background.cpp
 
 configuration.o: configuration.cpp configuration.h logging.h main.h
-	g++ -c $(DEBUGGING) configuration.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) configuration.cpp
 
 desktop.o: desktop.cpp desktop.h logging.h configuration.h sound.h grid.h
-	g++ -c $(DEBUGGING) $(XFTINC) $(HOURGLASSINCS) desktop.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) $(HOURGLASSINCS) desktop.cpp
 
 sound.o: sound.cpp sound.h
-	g++ -c $(DEBUGGING) sound.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) sound.cpp
 
 ssaver.o: ssaver.cpp ssaver.h
-	g++ -c $(DEBUGGING) ssaver.cpp
+	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) ssaver.cpp
 
 clean:
 	-rm *o kdesk kdesk-dbg

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -474,24 +474,19 @@ void Configuration::dump()
 
 void Configuration::reset(void)
 {
-  std::map<string,string>::iterator it;
-  for (it=configuration.begin(); it != configuration.end(); ++it)
-    {
-      configuration.erase(it);
-    }
+  // Erase each key->value pair for the global configuration map
+  configuration.erase(configuration.begin(), configuration.end());
 
+  // Then clear the map list
   configuration.clear();
   reset_icons();
 }
 
 void Configuration::reset_icons(void)
 {
-  std::map<string,string>::iterator it;
   for (int c=0; c < numicons; c++) {
-    for (it=icons[c].begin(); it != icons[c].end(); ++it)
-      {
-	icons[c].erase (it);
-      }
+      // Erase each key->value entry for all the icons
+      icons[c].erase(icons[c].begin(), icons[c].end());
   }
 
   icons.clear();

--- a/src/desktop.cpp
+++ b/src/desktop.cpp
@@ -79,7 +79,9 @@ bool Desktop::create_icons (Display *display)
   }
   else {
     // Do not use imlib2 cache by default. It occassionally messes up icon images.
-    cache_size = 0;
+    // Force a cache of 1 if no cache specified. This is to account for the free_image
+    // calls not being called as it causes memory leaks - see icon.cpp#destroy()
+    cache_size = 1;
     log ("Not using Imlib2 image cache");
   }
 
@@ -198,10 +200,10 @@ bool Desktop::destroy_icons (Display *display)
 	it->second->destroy(display);
 	delete it->second;
       }
-      iconHandlers.erase(it);
     }
 
-  // Then empty the list of icon handlers
+  // Then erase each window->handler mapping entry, and empty the map list
+  iconHandlers.erase(iconHandlers.begin(), iconHandlers.end());
   iconHandlers.clear();
   numicons = 0;
 

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -381,25 +381,37 @@ void Icon::destroy(Display *display)
 
   if (image != NULL) {
     imlib_context_set_image(image);
-    imlib_free_image_and_decache();
+    // FIXME: Freeing the images causes a segfault after a few iterations
+    // setting imlibi's cache to 1 makes the memory usage become stable
+    //imlib_free_image_and_decache();
+    //imlib_free_image();
+    image=NULL;
   }
 
   if (image_stamp != NULL) {
     imlib_context_set_image(image_stamp);
-    imlib_free_image_and_decache();
+    // FIXME: Freeing the images causes a segfault after a few iterations
+    // setting imlibi's cache to 1 makes the memory usage become stable
+    //imlib_free_image_and_decache();
+    //imlib_free_image();
+    image_stamp=NULL;
   }
 
   if (backsafe != NULL) {
     imlib_context_set_image(backsafe);
-    imlib_free_image_and_decache();
+    // FIXME: Freeing the images causes a segfault after a few iterations
+    // setting imlibi's cache to 1 makes the memory usage become stable
+    //imlib_free_image_and_decache();
+    //imlib_free_image();
+    backsafe=NULL;
   }
+
+  XDestroyWindow (display, win);
 
   // free the grid position just occupied if necessary
   if (is_grid == true) {
     pgrid->free_space_used (gridx, gridy);
   }
-
-  XDestroyWindow (display, win);
 }
 
 int Icon::get_icon_horizontal_placement (int image_width)


### PR DESCRIPTION
 * Moving to build kdesk using G++ 4.7 with Standard C++11, for better map iterators management
 * Simplified the map cleanup to a safer method in configuration loading and icon creations
 * Removed Imblib free_image calls, as they seem to leak and eventually cause problems
 * Forcing a cache of 1 if it’s not specified, so imlib2 cleans its internal buffers for each refresh "kdesk -r"
 * Moving icon’s window destroy call before removing it from the the grid space
