### PR TITLE
This changeset allows to specify transparency to each icon

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -344,6 +344,10 @@ bool Configuration::parse_icon (const char *directory, string fname, int iconid)
 	if (token == "Relative-To:") {
 	  icons[iconid]["relative-to"] = value;
 	}
+
+        if (token == "Transparency:") {
+          icons[iconid]["transparency"] = value;
+        }
       }
 
     ifile.close();

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -75,8 +75,14 @@ Icon::Icon (Configuration *loaded_conf, int iconidx)
     log ("Error allocating memory for iconMapGlow");
   }
 
-  // Icon transparency can be specified for all icons in the kdeskrc file.
-  transparency_value = configuration->get_config_int("transparency");
+  // Icon transparency can be specified for each icon,
+  // or globally for all icons in the kdeskrc file.
+  // 0 means full transparent, 255 is opaque.
+  transparency_value = configuration->get_icon_int(iconid, "transparency");
+  if (!transparency_value) {
+      transparency_value = configuration->get_config_int("transparency");
+  }
+
   if (transparency_value > 0) {
     log1 ("Found icon transparency setting", transparency_value);
     iconMapTransparency = (unsigned char *) calloc (sizeof(unsigned char), 256);


### PR DESCRIPTION
 * The key "Transparency" in the lnk files will be applied
   to each icon and take precedence over the global value in .kdeskrc