### PR TITLE
Kdesk new opion -j to find out where icons are on the desktop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kdesk (1.3-3) unstable; urgency=low
+
+  * Added command to find icon positions on the desktop (-j)
+
+ -- Team Kano <dev@kano.me>  Fri, 8 Jan 2016 12:35:00 +0000
+
 kdesk (1.3-2) unstable; urgency=low
 
   * Roll back to the grid to accomodate 7 icons per row

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,3 @@
+Files: *
+Copyright: 2014-2016 Kano Computing Ltd.
+License: GPL-2+

--- a/src/icon.cpp
+++ b/src/icon.cpp
@@ -404,12 +404,18 @@ Window Icon::create (Display *display, IconGrid *icon_grid)
   xftdraw1 = XftDrawCreate(display, win, DefaultVisual(display,0),DefaultColormap(display,0));
   log1("xftdraw1 is", xftdraw1);
   if( win == None ) {
-    log ("error creating windows");
+    log1 ("error creating window for icon", get_icon_filename());
   }
   else {
     XSelectInput(display, win, ButtonPressMask | ButtonReleaseMask | PointerMotionMask | ExposureMask | EnterWindowMask | LeaveWindowMask);
     XMapWindow(display, win);
     XLowerWindow(display, win);
+
+    // Expose the icon with a name in the X11 space,
+    // so tools like xwininfo can identify it, as well as "kdesk -j myIcon".
+    string icon_x11_name = string("kdesk-");
+    icon_x11_name += get_icon_name();
+    XStoreName(display, win, icon_x11_name.c_str());
   }
 
   // Set mouse cursor to "hand" when the mouse moves over the icon

--- a/src/version.h
+++ b/src/version.h
@@ -7,4 +7,4 @@
 // An app to show and bring life to Kano-Make Desktop Icons.
 //
 
-#define VERSION "1.02"
+#define VERSION "1.03"


### PR DESCRIPTION
 * Kdesk gives each desktop icon a unique name in the X11 namespace
 * A new option -j returns a json-like description of an icon coordinates and size
 * Tools like xdotool or xwininfo can also peek at the icons to send X11 events
 * Added missing copyright notice, and increased version

cc @alex5imon @convolu 
