### PR TITLE
Adding feature to register pixmap atoms for other compositors

### DIFF
--- a/src/background.h
+++ b/src/background.h
@@ -20,11 +20,13 @@ class Background
 
  public:
   bool running;
+  int screen;
 
  public:
   Background (Configuration *loaded_conf);
   virtual ~Background (void);
-  
+
+  int setRootAtoms (Display *display, Pixmap pixmap);
   bool setup (Display *display);
   bool load (Display *display);
   bool draw (Display *display);


### PR DESCRIPTION
@Ealdwulf this changeset fixes the desktop obfuscated areas when running the x compositor.

It's not completely working. From time to time there are still areas which do not redraw correctly.
Also eventually xcompmgr starts complaining about invalid windows at load time, which can be repaired by calling `kdesk -w`, which is a simple broadcast to tell all top level windows to redraw themselves.
