### PR TITLE
Fixed occassional unexpected termination

### DIFF
--- a/src/icon.h
+++ b/src/icon.h
@@ -91,6 +91,8 @@ class Icon
   bool maximize(Display *display, Window win);
   Window find_icon_window (Display *display, std::string appid);
 
+  static int IgnoreBadWindowExceptions(Display *display, XErrorEvent *error);
+
   void set_caption (char *new_caption);
   void set_message (char *new_message);
   void set_icon (char *new_icon);


### PR DESCRIPTION
 * When clicking on icons, it could be the case that for singleton apps,
   kdesk terminates unexpectedly. This is due to XQueryTree might
   raise a BadWindow exception.
 * Fixed by catching the exception.

cc @Ealdwulf 