### PR TITLE
Provides a new running modality to kdesk called "screen saver" with -s.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kdesk (1.5-3) unstable; urgency=low
+
+  * Added screen saver run mode with hooks, and no icons loaded
+
+ -- Team Kano <dev@kano.me>  Thu, 26 May 2016 17:58:00 +0100
+
 kdesk (1.4-3) unstable; urgency=low
 
   * Added automatic conversion and caching of SVG icons


### PR DESCRIPTION
 * In this mode no icons are loaded or processed. Only the screen saver runs.
 * The hooks related to the screen saver are properly called.
 * The wallpaper is also set during initialization.
 * Combined with -c allows to specify different timeouts and screen saver programs

Addresses: https://github.com/KanoComputing/peldins/issues/2372
