### PR TITLE
I18n icons localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,31 @@ Check all the detailed information in the [wiki](https://github.com/KanoComputin
 [Introduction](https://github.com/KanoComputing/kdesk/wiki/Introduction)  
 [Development](https://github.com/KanoComputing/kdesk/wiki/Development)  
 [Collaboration](https://github.com/KanoComputing/kdesk/wiki/Collaboration)  
+
+
+###Localization
+
+kdesk supports localization of two icon file types: `Icon` and `IconHover`.
+
+In your `lnk` icon files, simply set a path to the default international version of the asset,
+and kdesk will try to find the localized version of it on the fly, the lnk file will not be modified.
+For example, provided your LANG is set to `es_AR.UTF-8`:
+
+```
+Icon: /usr/share/my-app/icons/app.png
+IconHover: /usr/share/my-app/hovers/app-hover.png
+```
+
+Would be translated by kdesk to:
+
+```
+Icon: /usr/share/my-app/icons/i18n/es_AR/app.png
+IconHover: /usr/share/my-app/hovers/i18n/es_AR/app-hover.png
+```
+
+The `es_AR` will be obtained by querying the `LANG` environment variable, you can easily force it to test new locales.
+Testing the configuration on the debug version will tell you which icons are localized or missing:
+
+```
+LANG=zh_TW.Big5 ./kdesk-dbg -t | grep i18n0
+```

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ The `es_AR` will be obtained by querying the `LANG` environment variable, you ca
 Testing the configuration on the debug version will tell you which icons are localized or missing:
 
 ```
-LANG=zh_TW.Big5 ./kdesk-dbg -t | grep i18n0
+LANG=zh_TW.Big5 ./kdesk-dbg -t | grep i18n
 ```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kdesk (1.6-3) unstable; urgency=low
+
+  * Added support for localizing desktop icons
+
+ -- Team Kano <dev@kano.me>  Mon, 20 Feb 2017 15:33:00 +0100
+
 kdesk (1.5-3) unstable; urgency=low
 
   * Added screen saver run mode with hooks, and no icons loaded

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,6 @@ LIBS:=-lXft -lImlib2 -lstdc++ -lpthread -lX11 -lXss -L`pwd`/libkdesk-hourglass -
 XFTINC:=-I/usr/include/freetype2
 HOURGLASSINCS= -I`pwd`/libkdesk-hourglass
 
-GPLUSPLUS=g++-4.7
 CFLAGS=-std=c++11
 
 TARGET=kdesk
@@ -26,32 +25,32 @@ debug:
 
 # the linkage
 $(TARGET): main.o icon.o grid.o background.o configuration.o desktop.o sound.o ssaver.o
-	$(GPLUSPLUS) $(LIBS) $^ -o $(TARGET)
+	$(CC) $(LIBS) $^ -o $(TARGET)
 
 # the compilation
 icon.o: icon.cpp icon.h logging.h configuration.h grid.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) icon.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) icon.cpp
 
 grid.o: grid.cpp grid.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) grid.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) grid.cpp
 
 main.o: main.cpp main.h configuration.h logging.h version.h ssaver.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) main.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) main.cpp
 
 background.o: background.cpp logging.h sound.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) background.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) background.cpp
 
 configuration.o: configuration.cpp configuration.h logging.h main.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) configuration.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) configuration.cpp
 
 desktop.o: desktop.cpp desktop.h logging.h configuration.h sound.h grid.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) $(HOURGLASSINCS) desktop.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) $(XFTINC) $(HOURGLASSINCS) desktop.cpp
 
 sound.o: sound.cpp sound.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) sound.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) sound.cpp
 
 ssaver.o: ssaver.cpp ssaver.h
-	$(GPLUSPLUS) -c $(CFLAGS) $(DEBUGGING) ssaver.cpp
+	$(CXX) -c $(CFLAGS) $(DEBUGGING) ssaver.cpp
 
 clean:
 	-rm *o kdesk kdesk-dbg

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ debug:
 
 # the linkage
 $(TARGET): main.o icon.o grid.o background.o configuration.o desktop.o sound.o ssaver.o
-	$(CC) $(LIBS) $^ -o $(TARGET)
+	$(CXX) $(LIBS) $^ -o $(TARGET)
 
 # the compilation
 icon.o: icon.cpp icon.h logging.h configuration.h grid.h

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -379,37 +379,27 @@ string Configuration::localize_icon(string icon_filename)
             *dot = 0x00;
     }
 
-    // Split the path and filename (basename / basedir are harmful)
-    char localized[PATH_MAX], filename[PATH_MAX], path[PATH_MAX];
-    strcpy (localized, icon_filename.c_str());
-    char *path_ext=strrchr(localized, '/');
-    if (!path_ext) {
-        return (icon_filename);
-    }
-    else {
-        strcpy(filename, path_ext + sizeof(char));
-        *path_ext = 0x00;
-        strcpy(path, localized);
-    }
+    // Construct the path to new localized asset file
+    std::size_t path_ext = icon_filename.find_last_of("/\\");
+    std::string localized = icon_filename.substr(0, path_ext);
+    std::string filename = icon_filename.substr(path_ext + 1);
 
-    // Construct the new localized path to the icon
-    strcpy(localized, path);
-    strcat(localized, "/i18n/");
-    strcat(localized, current_locale);
-    strcat(localized, "/");
-    strcat(localized, filename);
+    localized += "/i18n/";
+    localized += current_locale;
+    localized += "/";
+    localized += filename;
 
     // If new localized icon cannot be found, return original one
     struct stat file_status;
     memset(&file_status, 0x00, sizeof(file_status));
-    int rc=stat (localized, &file_status);
+    int rc=stat (localized.c_str(), &file_status);
     if (rc != 0 || !S_ISREG(file_status.st_mode)) {
         log1("i18n localized icon not found", localized);
         return icon_filename;
     }
 
     log1("i18n setting localized icon", localized);
-    return std::string(localized);
+    return localized;
 }
 
 bool Configuration::parse_icon (const char *directory, string fname, int iconid)

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -401,8 +401,9 @@ string Configuration::localize_icon(string icon_filename)
 
     // If new localized icon cannot be found, return original one
     struct stat file_status;
-    stat (localized, &file_status);
-    if (!S_ISREG(file_status.st_mode)) {
+    memset(&file_status, 0x00, sizeof(file_status));
+    int rc=stat (localized, &file_status);
+    if (rc != 0 || !S_ISREG(file_status.st_mode)) {
         log1("i18n localized icon not found", localized);
         return icon_filename;
     }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -32,6 +32,7 @@ class Configuration
   bool load_icons (const char *directory);
   bool parse_icon (const char *directory, std::string fname, int iconid);
   std::string convert_svg(std::string icon_filename);
+  std::string localize_icon(std::string icon_filename);
   void dump (void);
   void reset(void);
   void reset_icons(void);

--- a/src/libkdesk-hourglass/Makefile
+++ b/src/libkdesk-hourglass/Makefile
@@ -28,30 +28,30 @@ clean:
 
 # the linkage
 $(TARGET): $(TARGET).o
-	g++ -shared -rdynamic -Wl,-soname,lib$(TARGET).so -o lib$(TARGET).so $(LIBS) $^ $(DEBUGGING)
+	$(CXX) -shared -rdynamic -Wl,-soname,lib$(TARGET).so -o lib$(TARGET).so $(LIBS) $^ $(DEBUGGING)
 
 # the compilation
 $(TARGET).o: $(TARGET).cpp $(TARGET).h
-	g++ -c -fPIC $(INCS) $(DEBUGGING) $(TARGET).cpp
+	$(CXX) -c -fPIC $(INCS) $(DEBUGGING) $(TARGET).cpp
 
 # C++ sample on how to use the kdesk hourglass library dynamically
 $(CPPTESTDYNLIB): $(CPPTESTDYNLIB).o
-	g++ $(CPPTESTDYNLIB).o -ldl -o $(CPPTESTDYNLIB)
+	$(CXX) $(CPPTESTDYNLIB).o -ldl -o $(CPPTESTDYNLIB)
 
 $(CPPTESTDYNLIB).o: $(CPPTESTDYNLIB).cpp
-	g++ -c $(CPPTESTDYNLIB).cpp
+	$(CXX) -c $(CPPTESTDYNLIB).cpp
 
 # C++ sample on how to use the kdesk hourglass library at build time
 $(CPPTESTSHARED): $(CPPTESTSHARED).o
-	g++ $(CPPTESTSHARED).o -L. -l$(TARGET) -o $(CPPTESTSHARED)
+	$(CXX) $(CPPTESTSHARED).o -L. -l$(TARGET) -o $(CPPTESTSHARED)
 
 $(CPPTESTSHARED).o: $(CPPTESTSHARED).cpp
-	g++ -c -g $(CPPTESTSHARED).cpp
+	$(CXX) -c -g $(CPPTESTSHARED).cpp
 
 # A command line tool to bring up the hourglass to a loading app
 $(KDESK_HOURGLASS_APP): $(KDESK_HOURGLASS_APP).o
-	g++ $(KDESK_HOURGLASS_APP).o -L. -l$(TARGET) -o $(KDESK_HOURGLASS_APP)
+	$(CXX) $(KDESK_HOURGLASS_APP).o -L. -l$(TARGET) -o $(KDESK_HOURGLASS_APP)
 
 $(KDESK_HOURGLASS_APP).o: $(KDESK_HOURGLASS_APP).cpp
-	g++ -c -g $(KDESK_HOURGLASS_APP).cpp
+	$(CXX) -c -g $(KDESK_HOURGLASS_APP).cpp
 


### PR DESCRIPTION
This changeset provides a way for kdesk to localize icon files on the fly.
The original paths are modified at run time to try to find the localized version combining the LANG setting and a separate subdirectory.

More details on the README file.

@tombettany @radujipa 
