### PR TITLE
Screen saver trigger

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -173,11 +173,13 @@ bool Configuration::load_conf(const char *filename)
       if (token == "ScreenSaverTimeout:") {
 	ifile >> value;
 	configuration["screensavertimeout"] = value;
+        log1("found ScreenSaverTimeout:", value)
       }
 
       if (token == "ScreenSaverProgram:") {
 	ifile >> value;
 	configuration["screensaverprogram"] = value;
+        log1("found ScreenSaverProgram:", value)
       }
 
       if (token == "OneClick:") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -319,12 +319,14 @@ int main(int argc, char *argv[])
       // And override any settings provided by the user's home dir configuration
       kprintf ("loading generic configuration file: %s\n", strKdeskRC.c_str());
       bgeneric = conf.load_conf(strKdeskRC.c_str());
-      kprintf ("overriding settings with home configuration file: %s\n", strHomeKdeskRC.c_str());
-      buser = conf.load_conf(strHomeKdeskRC.c_str());
-      if (bgeneric == false && buser == false) {
-          kprintf ("could not read generic or user configuration settings\n");
-          exit(1);
-      }
+  }
+
+  // combine loaded configuration with custom settings located in the users HOME dir
+  kprintf ("overriding settings with home configuration file: %s\n", strHomeKdeskRC.c_str());
+  buser = conf.load_conf(strHomeKdeskRC.c_str());
+  if (bgeneric == false && buser == false) {
+      kprintf ("could not read generic or user configuration settings\n");
+      exit(1);
   }
 
   log1 ("loading icons from directory", strKdeskDir.c_str());

--- a/src/ssaver.cpp
+++ b/src/ssaver.cpp
@@ -109,10 +109,11 @@ void fake_user_input (Display *display)
 
   // From the docs: If dest_w is None, XWarpPointer() moves the pointer by the offsets
   // (dest_x, dest_y) relative to the current position of the pointer
-  XWarpPointer(display, root, 0, // Display, source window, destination window
-               0, 0, 0, 0,       // source x,y and width, height
-               1, 1);            // destination x,y
+  int rc=XWarpPointer(display, root, 0,     // Display, source window, destination window
+                      0, 0, 0, 0,          // source x,y and width, height
+                      1, 1);               // destination x,y
 
+  log1("xwarppointer fake user input returns with rc", rc)
   XFlush(display);
 }
 
@@ -146,10 +147,12 @@ void *idle_time (void *p)
     {
       rc = XScreenSaverQueryInfo(display, DefaultRootWindow(display), info);
       log3 ("asking for system idle time - rcsuccess, T/O, and idle time in secs", rc, info->idle / 1000, pdata->idle_timeout);
+      log2 ("current tty, default X tty", get_current_console(), GUI_TTY_DEVICE);
       if (rc)
 	{
-	  // If idle timeout expires, and focus is on the GUI tty device, then launch the screen saver
-	  if (info->idle > (pdata->idle_timeout * 1000) && get_current_console() == GUI_TTY_DEVICE) {
+          // If idle timeout expires, then launch the screen saver
+          // Note that this would trigger the screen saver whilst on a tty console as well
+	  if (info->idle > (pdata->idle_timeout * 1000)) {
 	    rchook = hook_ssaver_start(pdata->saver_hooks);
 	    if (rchook == 0) {
 	      log2 ("Starting the Screen Saver (idle, timeout in secs)", info->idle / 1000, pdata->idle_timeout);

--- a/tests/configurations/kdeskrc_test
+++ b/tests/configurations/kdeskrc_test
@@ -1,0 +1,87 @@
+# .kdeskrc
+#
+# Copyright (C) 2014,2015 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+#
+#
+
+
+table Config
+  FontName: Bariol
+  FontSize: 14
+  SubtitleFontSize: 11
+  FontColor: #323232
+
+  ToolTip.FontSize: 10
+  ToolTip.FontName: Bariol
+  ToolTip.ForeColor: #0000FF
+  ToolTip.BackColor: #FFFFFF
+  ToolTip.CaptionOnHover: false
+  ToolTip.CaptionPlacement: Right
+  Locked: true
+
+  EnableSound: true
+  SoundWelcome: /usr/share/kano-media/sounds/kano_boot_up.wav
+  SoundLaunchApp: /usr/share/kano-media/sounds/kano_open_app.wav
+  SoundDisabledIcon: /usr/share/kano-media/sounds/kano_error.wav
+
+  ScreenSaverTimeout: 30
+  ScreenSaverProgram: /usr/bin/qmlmatrix
+
+  OneClick: true
+  MaximizeSingleton: true
+
+  IconHook: /usr/share/kano-desktop/kdesk/icon-hooks.sh
+
+  DefaultDesktopIcon: /usr/share/kano-desktop/icons/default-icon.png
+
+  LastGridIcon: PlusIcon.lnk
+
+  IconGapHorz: 54
+  IconGapVert: 10
+
+  GridWidth: 90
+  GridHeight: 125
+
+  GridIconWidth: 88
+  GridIconHeight: 88
+
+  Transparency: 0
+  Shadow: true
+  ShadowColor: #6e6e6e
+  ShadowX: 1
+  ShadowY: 1
+  Bold: true
+  ClickDelay: 300
+  IconStartDelay: 5000
+  IconSnap: true
+  IconTitleGap: 0
+  SnapWidth: 10
+  SnapHeight: 10
+  SnapOrigin: BottomRight
+  SnapShadow: false
+  SnapShadowTrans: 200
+  CaptionOnHover: false
+  CaptionPlacement: bottom
+  FillStyle: None
+  Background.Delay: 0
+  Background.Source: /
+
+  ScreenMedResWidth: 1025
+  Background.File-medium: /usr/share/kano-desktop/wallpapers/kanux-default-1024.png
+  Background.File-4-3: /usr/share/kano-desktop/wallpapers/kanux-default-4-3.png
+  Background.File-16-9: /usr/share/kano-desktop/wallpapers/kanux-default-16-9.png
+  Background.Mode: scale
+  Background.Color: #C2CCFF
+end
+
+table Actions
+#  Lock: control right doubleClk
+#  Reload: middle doubleClk
+#  Drag: left hold
+#  EndDrag: left singleClk
+
+  Execute[0]: left doubleClk
+
+#  Execute[1]: right doubleClk
+end

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -7,8 +7,12 @@
 import os
 
 def run_kdesk_configuration(configuration):
+
+    # allow the tests to run either isolated on this repo, or on a kano os image / real RPI
+    os.environ["PATH"] = '../src:' + os.environ['PATH']
+
     # we run kdesk in test mode, possibly with custom configuration file
-    command='../src/kdesk-dbg -v -t'
+    command='kdesk-dbg -v -t'
     if configuration:
         command += ' -c {}'.format(configuration)
     return os.popen(command).read()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+#
+#  Tests that kdesk uses the correct configuration settings
+#  by merging HOME settings into the main configuration file.
+#
+
+import os
+
+def run_kdesk_configuration(configuration):
+    # we run kdesk in test mode, possibly with custom configuration file
+    command='../src/kdesk-dbg -v -t'
+    if configuration:
+        command += ' -c {}'.format(configuration)
+    return os.popen(command).read()
+
+def test_config_custom():
+    config_file='configurations/kdeskrc_test'
+    out=run_kdesk_configuration(config_file)
+    assert(out.find('loading custom configuration file: {}'.format(config_file)) != -1)
+
+def test_config_custom_ssaver():
+    config_file='configurations/kdeskrc_test'
+    out=run_kdesk_configuration(config_file)
+    assert(out.find('found ScreenSaverTimeout: 30') != -1)
+    assert(out.find('found ScreenSaverProgram: /usr/bin/qmlmatrix') != -1)
+
+def test_config_combined_with_default():
+    with open('{}/.kdeskrc'.format(os.getenv("HOME")), 'w') as f:
+        f.write('ScreenSaverTimeout: 10')
+
+    out=run_kdesk_configuration(None)
+    assert(out.find('found ScreenSaverTimeout: 10') != -1)
+
+def test_config_combined_with_custom():
+    config_file='configurations/kdeskrc_test'
+    with open('{}/.kdeskrc'.format(os.getenv("HOME")), 'w') as f:
+        f.write('ScreenSaverTimeout: 10')
+
+    out=run_kdesk_configuration(config_file)
+    assert(out.find('found ScreenSaverTimeout: 10') != -1)


### PR DESCRIPTION
This changeset gives two fixes:

 * On a multiuser kit, the inactivity timeout for the screen saver was not detected
 * When using a custom configuration file, user HOME settings were not combined
 * Added tests for the second fix above

Additionally it provides the screen saver to start up even when on tty consoles.
Do a `pip install pytest` to run the tests below. Tests pass on xsysroot and RPi

```
kano@KXBN001 /tmp/kdesk/tests $ pytest -v
============================================================== test session starts ==============================================================
platform linux2 -- Python 2.7.9, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python
cachedir: .cache
rootdir: /tmp/kdesk/tests, inifile:
collected 4 items

test_configuration.py::test_config_custom PASSED
test_configuration.py::test_config_custom_ssaver PASSED
test_configuration.py::test_config_combined_with_default PASSED
test_configuration.py::test_config_combined_with_custom PASSED

=========================================================== 4 passed in 0.52 seconds ============================================================
```
