### PR TITLE
Fix regression with combining configuration files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,7 +300,7 @@ int main(int argc, char *argv[])
   kprintf ("initializing...\n");
   struct passwd *pw = getpwuid(getuid());
   const char *homedir = pw->pw_dir;
-  bool bgeneric, buser = false;
+  bool bconf, buser = false;
   strKdeskRC     = FILE_KDESKRC;
   strHomeKdeskRC = homedir + string("/") + string(FILE_HOME_KDESKRC);
   strKdeskDir    = DIR_KDESKTOP;
@@ -309,7 +309,8 @@ int main(int argc, char *argv[])
   // Load a custom configuration
   if (configuration_file.length()) {
       kprintf ("loading custom configuration file: %s\n", configuration_file.c_str());
-      if (conf.load_conf(configuration_file.c_str()) == false) {
+      bconf = conf.load_conf(configuration_file.c_str());
+      if (!bconf) {
           kprintf ("could not read custom configuration settings\n");
           exit(1);
       }
@@ -318,13 +319,13 @@ int main(int argc, char *argv[])
       // Load system wide configuration file from /usr/share
       // And override any settings provided by the user's home dir configuration
       kprintf ("loading generic configuration file: %s\n", strKdeskRC.c_str());
-      bgeneric = conf.load_conf(strKdeskRC.c_str());
+      bconf = conf.load_conf(strKdeskRC.c_str());
   }
 
   // combine loaded configuration with custom settings located in the users HOME dir
   kprintf ("overriding settings with home configuration file: %s\n", strHomeKdeskRC.c_str());
   buser = conf.load_conf(strHomeKdeskRC.c_str());
-  if (bgeneric == false && buser == false) {
+  if (bconf == false && buser == false) {
       kprintf ("could not read generic or user configuration settings\n");
       exit(1);
   }

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -42,3 +42,22 @@ def test_config_combined_with_custom():
 
     out=run_kdesk_configuration(config_file)
     assert(out.find('found ScreenSaverTimeout: 10') != -1)
+
+def test_config_combined_with_absent_home():
+    config_file='configurations/kdeskrc_test'
+    homeconf='{}/.kdeskrc'.format(os.getenv("HOME"))
+    if os.path.isfile(homeconf):
+        os.remove(homeconf)
+
+    out=run_kdesk_configuration(config_file)
+    assert(out.find('found ScreenSaverTimeout: 30') != -1)
+    assert(out.find('could not read generic or user configuration settings') == -1)
+
+def test_config_custom_missing():
+    config_file='configurations/nonexistent'
+    homeconf='{}/.kdeskrc'.format(os.getenv("HOME"))
+    if os.path.isfile(homeconf):
+        os.remove(homeconf)
+
+    out=run_kdesk_configuration(config_file)
+    assert(out.find('Could not find configuration file: {}'.format(config_file)) != -1)


### PR DESCRIPTION
On my previous PR I introduced a regression issue, where if a custom configuration file is specified, without a home directory counterpart, kdesk would refuse to start.

Fixed and added tests for this use case. Works fine on the PI.

```
kano@KXBN001 /tmp/kdesk/tests $ pytest -v
============================================================== test session starts ==============================================================
platform linux2 -- Python 2.7.9, pytest-3.2.0, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python
cachedir: .cache
rootdir: /tmp/kdesk/tests, inifile:
collected 6 items

test_configuration.py::test_config_custom PASSED
test_configuration.py::test_config_custom_ssaver PASSED
test_configuration.py::test_config_combined_with_default PASSED
test_configuration.py::test_config_combined_with_custom PASSED
test_configuration.py::test_config_combined_with_absent_home PASSED
test_configuration.py::test_config_custom_missing PASSED

=========================================================== 6 passed in 0.71 seconds ============================================================
```
