### PR TITLE
Fixing graphic noise on Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Check all the detailed information in the [wiki](https://github.com/KanoComputin
 [Collaboration](https://github.com/KanoComputing/kdesk/wiki/Collaboration)  
 
 
-###Localization
+### Localization
 
 kdesk supports localization of two icon file types: `Icon` and `IconHover`.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kdesk (4.0.0-0) unstable; urgency=low
+
+  * Build for Debian Stretch
+  * Added flag -m to disable MIT-SHM XServer extension
+
+ -- Team Kano <dev@kano.me>  Tue, 22 May 2018 14:46:00 +0100
+
 kdesk (1.6-3) unstable; urgency=low
 
   * Added support for localizing desktop icons


### PR DESCRIPTION
This PR fixes a rendering problem with the latest version of imlib2 and the Xserver on Debian Stretch. By `xtracing` kdesk, we noticed that it relates to the MIT-SHM extension.

The solution provided is to disabling this extension for kdesk, by default. Additionally, a command line option allows to enable it back if necessary.

Tested on the PI running Kano OS Stretch and seems to now work fine.
