### PR TITLE
Fixes screen saver which stopped working on Stretch build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kdesk (4.0.1-0) unstable; urgency=low
+
+  * Fixed a memory leak that stopped screen saver from working
+
+ -- Team Kano <dev@kano.me>  Tue, 29 May 2018 15:27:00 +0100
+
 kdesk (4.0.0-0) unstable; urgency=low
 
   * Build for Debian Stretch

--- a/src/ssaver.h
+++ b/src/ssaver.h
@@ -17,10 +17,10 @@
 
 typedef struct _ksaver_data {
 
-  const char *display_name;           // Usually this can be set to NULL to attach to first available display
-  unsigned long idle_timeout;         // seconds to idle before starting the screen saver
-  const char *saver_program;          // path to binary program that paints the screen saver
-  const char *saver_hooks;            // path to a hook script that will be executed to alert on screen saver transitions (start, finish)
+  char *display_name;           // Usually this can be set to NULL to attach to first available display
+  unsigned long idle_timeout;   // seconds to idle before starting the screen saver
+  char *saver_program;          // path to binary program that paints the screen saver
+  char *saver_hooks;            // path to a hook script that will be executed to alert on screen saver transitions (start, finish)
 
 } KSAVER_DATA;
 


### PR DESCRIPTION
The screen saver was not working on the latest build for Stretch.
A memory leak passing the strings to the screen saver thread, was breaking the literals.
Fixed by making a copy of said strings.
Why did we not see this until now? My guess is because we've migrated the libc library.

Tested on the PI and seems to work flawlessly back again.
